### PR TITLE
Show and hides breadcrumbs based on router and state

### DIFF
--- a/apps/obs-wcgop-optecs/package.json
+++ b/apps/obs-wcgop-optecs/package.json
@@ -29,7 +29,8 @@
     "vue-router": "^3.0.1",
     "vue-touch-keyboard": "^0.3.1",
     "vuex": "^3.0.1",
-    "vuex-class": "^0.3.2"
+    "vuex-class": "^0.3.2",
+    "vuex-persist": "^2.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.0",

--- a/apps/obs-wcgop-optecs/src/_store/index.ts
+++ b/apps/obs-wcgop-optecs/src/_store/index.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import Vuex, { StoreOptions } from 'vuex';
+import VuexPersist from 'vuex-persist';
 
 import { appState } from '@/_store/wcgop-app-state.module';
 import { alert } from '@/_store/alert.module';
@@ -14,6 +15,12 @@ import { RootState } from '@/_store/types/types';
 
 Vue.use(Vuex);
 
+// Preserves state between page refreshes.
+const vuexLocalStorage = new VuexPersist({
+  key: 'vuex',
+  storage: window.localStorage
+});
+
 const store: StoreOptions<RootState> = {
   state: {
     version: '1.0.0'
@@ -23,7 +30,8 @@ const store: StoreOptions<RootState> = {
     alert,
     auth,
     baseCouch
-  }
+  },
+  plugins: [vuexLocalStorage.plugin]
 };
 
 export default new Vuex.Store<RootState>(store);

--- a/apps/obs-wcgop-optecs/src/assets/directional-buttons.css
+++ b/apps/obs-wcgop-optecs/src/assets/directional-buttons.css
@@ -7,20 +7,20 @@
    padding-left: 18px;
    padding-right: 18px;
 }
- 
+
 .btn-arrow-right,
 .btn-arrow-right-only {
    padding-left: 24px;
 }
- 
+
 .btn-arrow-left {
    padding-right: 25px;
 }
 
- /* There's a default setting, so overriding it */
- .q-btn--standard:not(.disabled):before {
-    top: 5px;
-    left: -12px;
+/* There's a default setting, so overriding it */
+.q-btn--standard:not(.disabled):before {
+   top: 5px;
+   left: -12px;
 }
 
 .btn-arrow-right:before,
@@ -34,81 +34,78 @@
    position: absolute;
    top: 5px;
    /* move it down because of rounded corners */
-    
+
    width: 26px;
    /* same as height */
-    
+
    height: 26px;
    /* button_outer_height / sqrt(2) */
-    
+
    background: inherit;
    /* use parent background */
-    
+
    border: inherit;
    /* use parent border */
-    
+
    border-left-color: transparent;
    /* hide left border */
-    
+
    border-bottom-color: transparent;
    /* hide bottom border */
-    
+
    border-radius: 0px 4px 0px 0px;
    /* round arrow corner, the shorthand property doesn't accept "inherit" so it is set to 4px */
-    
+
    -webkit-border-radius: 0px 4px 0px 0px;
    -moz-border-radius: 0px 4px 0px 0px;
 }
- 
+
 .btn-arrow-right:before,
 .btn-arrow-right:after,
 .btn-arrow-right-only:after {
    transform: rotate(45deg);
    /* rotate right arrow squares 45 deg to point right */
-    
+
    -webkit-transform: rotate(45deg);
    -moz-transform: rotate(45deg);
    -o-transform: rotate(45deg);
    -ms-transform: rotate(45deg);
 }
- 
+
 .btn-arrow-left:before,
 .btn-arrow-left:after {
    transform: rotate(225deg);
    /* rotate left arrow squares 225 deg to point left */
-    
+
    -webkit-transform: rotate(225deg);
    -moz-transform: rotate(225deg);
    -o-transform: rotate(225deg);
    -ms-transform: rotate(225deg);
 }
- 
+
 .btn-arrow-right:before,
 .btn-arrow-left:before {
    /* align the "before" square to the left */ 
    left: -11px;
- }
- 
+}
+
 .btn-arrow-right:after,
 .btn-arrow-left:after,
 .btn-arrow-right-only:after {
    /* align the "after" square to the right */
-    
    right: -12px;
 }
- 
+
 .btn-arrow-right:after,
 .btn-arrow-left:before,
 .btn-arrow-right-only:after {
    /* bring arrow pointers to front */
-    
    z-index: 1;
 }
- 
+
 .btn-arrow-right:before,
 .btn-arrow-left:after {
    /* hide arrow tails background */
-    
    background-color: #027be3;
 }
 
@@ -116,4 +113,5 @@
 .btn-group > .btn-arrow-left:hover, .btn-group > .btn-arrow-left:focus,
 .btn-group > .btn-arrow-right:hover,
 .btn-group > .btn-arrow-right:focus {
-  z-index: initial; }
+   z-index: initial;
+}

--- a/apps/obs-wcgop-optecs/src/components/OptecsBreadcrumbs.vue
+++ b/apps/obs-wcgop-optecs/src/components/OptecsBreadcrumbs.vue
@@ -15,54 +15,33 @@
         class="btn-arrow-right"
         :color="i != breadcrumbs.length-1 ? 'white' : 'secondary'"
         :text-color="i != breadcrumbs.length-1 ? 'primary' : 'white'"
-        :to="crumb.path"
-      >{{crumb.value ? crumb.value : crumb.name}}</q-btn>
+        :to="i != breadcrumbs.length-1 ? 'crumb.link' : ''"
+      >{{crumb.name}}</q-btn>
     </span>
   </q-btn-group>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Watch, Vue } from 'vue-property-decorator';
-import router from '../router';
+import { WcgopAppState } from '../_store/types/types';
+import { State, Action } from 'vuex-class';
 
 @Component
 export default class OptecsBreadcrumbs extends Vue {
-  // want to store this in state.
-  private breadcrumbs = [{ name: 'trips', path: '/', value: 0 }];
+  private breadcrumbs = [];
+  @State('appState') private appState!: WcgopAppState;
 
   @Watch('$route', { immediate: true, deep: true })
   private onUrlChange(newVal: any) {
-    const pageName = this.$router.currentRoute.name;
-    const path = this.$router.currentRoute.path;
-    let index = this.breadcrumbs.length - 1;
-
-    if (pageName == null) {
-      return;
-    }
-
-    // if navigating up, remove additional children
-    if (this.breadcrumbs.find((crumb) => crumb.name === pageName)) {
-      while (
-        !this.breadcrumbs[index].name.match(pageName) &&
-        this.breadcrumbs[index].name !== 'trips'
-      ) {
-        this.breadcrumbs.pop();
-        index--;
+    for (const crumb of this.$route.meta.breadcrumb) {
+      if (crumb.name.match('tripIdPlaceholder')) {
+        const tripNum = this.appState.currentTrip ? this.appState.currentTrip.tripNum : 0;
+        crumb.name = tripNum;
+        crumb.link = crumb.link + tripNum;
       }
+      // TODO read state and populate haulId and species
     }
-
-    if (!pageName.match('trips')) {
-      this.breadcrumbs.push({
-        name: pageName,
-        path,
-        value: this.getId(path)
-      });
-    }
-  }
-
-  private getId(path: string) {
-    const pathContainer = path.split('/');
-    return Number(pathContainer[2]);
+    this.breadcrumbs = this.$route.meta.breadcrumb;
   }
 }
 </script>

--- a/apps/obs-wcgop-optecs/src/router.ts
+++ b/apps/obs-wcgop-optecs/src/router.ts
@@ -26,13 +26,24 @@ const router = new Router({
         {
           path: '',
           name: 'trips',
-          component: Trips
+          component: Trips,
+          meta: {
+            breadcrumb: [
+              { name: 'Trip'}
+            ]
+          }
         },
         {
           path: '/tripdetails/:tripNum',
           name: 'tripdetails',
           component: TripDetails,
-          props: (route) => ({ tripNum: Number(route.params.tripNum) })
+          props: (route) => ({ tripNum: Number(route.params.tripNum) }),
+          meta: {
+            breadcrumb: [
+              { name: 'Trip', link: '' },
+              { name: 'tripIdPlaceholder', link: ''}
+            ]
+          }
         },
         {
           path: '/settings',
@@ -42,13 +53,28 @@ const router = new Router({
         {
           path: '/hauls',
           name: 'hauls',
-          component: Hauls
+          component: Hauls,
+          meta: {
+            breadcrumb: [
+              { name: 'Trip', link: '' },
+              { name: 'tripIdPlaceholder', link: '/tripdetails/'},
+              { name: 'Hauls', link: ''}
+            ]
+          }
         },
         {
           path: '/hauldetails/:haulNum',
           name: 'hauldetails',
           component: HaulDetails,
-          props: (route) => ({ haulNum: Number(route.params.haulNum) })
+          props: (route) => ({ haulNum: Number(route.params.haulNum) }),
+          meta: {
+            breadcrumb: [
+              { name: 'Trip', link: '' },
+              { name: 'tripIdPlaceholder', link: '/tripdetails/'},
+              { name: 'Hauls', link: '/hauls'},
+              { name: 'haulIdPlaceholder', link: ''}
+            ]
+          }
         }
       ]
     }, // otherwise redirect to home


### PR DESCRIPTION
Store breadcrumbs in router's metadata after following this https://medium.com/@fagnersaraujo/automated-breadcrumbs-with-vuejs-7e1051de8028. 

TripId, haulId, and species, will be populated from state. 

Added vuex-persist to preserve state between page refreshes 
https://alligator.io/vuejs/vuex-persist-state/

To test
1. Go to trips, select a trip and notice state changes
2. Navigate to another page, /hauls, /tripdetails, and you should see the trip you selected earlier is displayed in the breadcrumb. 