### PR TITLE
Fix build: revert typescript to 3.4.2

### DIFF
--- a/apps/dev-auth-server/package.json
+++ b/apps/dev-auth-server/package.json
@@ -22,7 +22,7 @@
     "@types/pem-jwk": "^1.5.0",
     "nodemon": "^1.18.10",
     "ts-node": "^8.0.2",
-    "typescript": "^3.4.2"
+    "typescript": "3.4.2"
   },
   "dependencies": {
     "@boatnet/bn-auth": "file:..\\..\\libs\\bn-auth",

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -18,7 +18,7 @@
     "vue-class-component": "^6.0.0",
     "vue-property-decorator": "^7.0.0",
     "vue-router": "^3.0.1",
-    "vuex": "^3.0.1"
+    "vuex": "3.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.0",
@@ -38,7 +38,7 @@
     "sass-loader": "^7.1.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
-    "typescript": "^3.0.0",
+    "typescript": "3.4.2",
     "vue-cli-plugin-quasar": "^1.0.0-beta.0",
     "vue-template-compiler": "^2.5.21"
   },

--- a/apps/obs-wcgop-optecs/package.json
+++ b/apps/obs-wcgop-optecs/package.json
@@ -30,7 +30,7 @@
     "vue-property-decorator": "^7.0.0",
     "vue-router": "^3.0.1",
     "vue-touch-keyboard": "^0.3.1",
-    "vuex": "^3.0.1",
+    "vuex": "3.1.0",
     "vuex-class": "^0.3.2",
     "vuex-persist": "^2.0.0"
   },
@@ -53,7 +53,7 @@
     "sass-loader": "^7.1.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
-    "typescript": "^3.4.2",
+    "typescript": "3.4.2",
     "vue-cli-plugin-quasar": "^1.0.0-beta.0",
     "vue-template-compiler": "^2.5.21"
   }

--- a/apps/obs-web/package.json
+++ b/apps/obs-web/package.json
@@ -32,7 +32,7 @@
     "register-service-worker": "^1.5.2",
     "vue": "^2.6.6",
     "vue-router": "^3.0.1",
-    "vuex": "^3.0.1",
+    "vuex": "3.1.0",
     "vuex-class": "^0.3.2"
   },
   "devDependencies": {
@@ -54,7 +54,7 @@
     "sass-loader": "^7.1.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
-    "typescript": "^3.4.2",
+    "typescript": "3.4.2",
     "vue-class-component": "^7.0.1",
     "vue-cli-plugin-quasar": "^1.0.0-beta.0",
     "vue-property-decorator": "^8.0.0",

--- a/apps/surv-hake-wetlab/package.json
+++ b/apps/surv-hake-wetlab/package.json
@@ -16,7 +16,7 @@
     "vue-class-component": "^6.0.0",
     "vue-property-decorator": "^7.0.0",
     "vue-router": "^3.0.1",
-    "vuex": "^3.0.1"
+    "vuex": "3.1.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.0",
@@ -32,7 +32,7 @@
     "chai": "^4.1.2",
     "node-sass": "^4.9.0",
     "sass-loader": "^7.1.0",
-    "typescript": "^3.2.1",
+    "typescript": "3.4.2",
     "vue-template-compiler": "^2.5.21"
   }
 }

--- a/libs/bn-auth/package.json
+++ b/libs/bn-auth/package.json
@@ -30,7 +30,7 @@
     "sass-loader": "^7.1.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
-    "typescript": "^3.4.2",
+    "typescript": "3.4.2",
     "vue-cli-plugin-quasar": "^1.0.0-beta.0",
     "vue-template-compiler": "^2.5.21"
   },

--- a/libs/bn-common/package.json
+++ b/libs/bn-common/package.json
@@ -22,7 +22,7 @@
     "fibers": "^3.1.1",
     "sass": "^1.16.0",
     "sass-loader": "^7.1.0",
-    "typescript": "^3.4.2",
+    "typescript": "3.4.2",
     "vue-template-compiler": "^2.5.21"
   }
 }

--- a/libs/bn-couch/package.json
+++ b/libs/bn-couch/package.json
@@ -31,7 +31,7 @@
     "sass-loader": "^7.1.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
-    "typescript": "^3.4.2",
+    "typescript": "3.4.2",
     "vue-cli-plugin-quasar": "^1.0.0-beta.0",
     "vue-template-compiler": "^2.5.21"
   },

--- a/libs/bn-models/package.json
+++ b/libs/bn-models/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.6",
-    "typescript": "^3.4.2"
+    "typescript": "3.4.2"
   },
   "license": "MIT",
   "dependencies": {

--- a/libs/bn-pouch/package.json
+++ b/libs/bn-pouch/package.json
@@ -37,7 +37,7 @@
     "sass-loader": "^7.1.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",
-    "typescript": "^3.4.2",
+    "typescript": "3.4.2",
     "vue-cli-plugin-quasar": "^1.0.0-beta.0",
     "vue-template-compiler": "^2.5.21"
   },

--- a/libs/bn-util/package.json
+++ b/libs/bn-util/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -d --module commonjs --outDir dist/"
   },
   "devDependencies": {
-    "typescript": "^3.4.2"
+    "typescript": "3.4.2"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Vuex-persist plugin seems to explode with typescript 3.5.1+, may file a bug.
Alternatively we might fix this by removing class syntax from our Vuex stores.
