### PR TITLE
Adding hauls page columns, associating trips to hauls #296

### DIFF
--- a/apps/obs-wcgop-optecs/package.json
+++ b/apps/obs-wcgop-optecs/package.json
@@ -21,6 +21,7 @@
     "davenport": "^2.8.2",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.25",
+    "pdfmake": "^0.1.56",
     "pouch-vue": "^0.1.37",
     "pouchdb-authentication": "^1.1.3",
     "pouchdb-browser": "^7.0.0",

--- a/apps/obs-wcgop-optecs/src/_store/index.ts
+++ b/apps/obs-wcgop-optecs/src/_store/index.ts
@@ -7,6 +7,7 @@ import { alert } from '@/_store/alert.module';
 import { auth } from '@boatnet/bn-auth';
 import { pouchState } from '@boatnet/bn-pouch';
 import { tallyState } from '@/_store/tally.module';
+import { pdfState } from '@/_store/pdf.module';
 
 import { RootState } from '@/_store/types/types';
 
@@ -31,7 +32,8 @@ const store: StoreOptions<RootState> = {
     alert,
     auth,
     pouchState,
-    tallyState
+    tallyState,
+    pdfState
   },
   plugins: [vuexLocalStorage.plugin]
 };

--- a/apps/obs-wcgop-optecs/src/_store/pdf.module.ts
+++ b/apps/obs-wcgop-optecs/src/_store/pdf.module.ts
@@ -1,0 +1,183 @@
+// Uses http://pdfmake.org/
+// https://stackoverflow.com/questions/50576746/import-pdfmake-js-file-to-my-ts-file
+import * as pdfMake from 'pdfmake/build/pdfmake.js';
+import * as pdfFonts from 'pdfmake/build/vfs_fonts.js';
+pdfMake.vfs = pdfFonts.pdfMake.vfs;
+
+import moment from 'moment';
+import Vue from 'vue';
+import Vuex, { Module, ActionTree, MutationTree } from 'vuex';
+import { RootState, PdfState } from '@/_store/types/types';
+import { TallyCountData } from './types';
+
+Vue.use(Vuex);
+
+export const state: PdfState = {
+  tripId: 'Not Set',
+  haulId: 'Not Set',
+  catchId: 'Not Set'
+};
+
+// Species Map
+const speciesMap = new Map();
+
+// Helper Functions
+
+function generateTallyPdfData(newState: PdfState, tallyData: TallyCountData[]) {
+  const header = [
+    'Code',
+    'Species',
+    'Weight Method',
+    'Tally Count',
+    'Total Wt.',
+    'Disp.',
+    'Wt. Calc'
+  ];
+
+  const pdfData: any[] = [header];
+  // Sort tallyData by Code
+  tallyData.sort(
+    (n1: TallyCountData, n2: TallyCountData) => {
+      if (n1.shortCode === n2.shortCode) {
+        return 0;
+      } else {
+        return n1!.shortCode! > n2!.shortCode! ? 1 : -1;
+      }
+    }
+  );
+
+  // Sort tallyData by disposition
+  tallyData.sort(
+    (n1: TallyCountData, n2: TallyCountData) => {
+      if (n1.reason === n2.reason) {
+        return 0;
+      } else {
+        return n1!.reason! > n2!.reason! ? 1 : -1;
+      }
+    }
+  );
+  tallyData.forEach((data) => {
+    if (data.count) {
+      const tww = data.calculatedTotalWeighedWeight
+        ? data.calculatedTotalWeighedWeight.toFixed(2)
+        : '';
+      const twc = data.calculatedTotalWeighedCount
+        ? data.calculatedTotalWeighedCount
+        : '';
+      const avgwt = data.calculatedAverageWeight
+        ? data.calculatedAverageWeight.toFixed(2)
+        : '';
+      const calculations =
+        'Weighed ' + twc + ' @ ' + tww + ' (Avg. Wt. = ' + avgwt + ' )';
+      const totalWeight =
+        data.count *
+        (data.calculatedAverageWeight ? data.calculatedAverageWeight : 0);
+      const commonName = speciesMap.get(data.shortCode);
+      pdfData.push([
+        { text: data.shortCode, bold: true },
+        { text: commonName, italics: true },
+        { text: '13', alignment: 'center' },
+        { text: data.count },
+        { text: tww ? totalWeight.toFixed(2) : '', bold: true },
+        { text: data.reason, alignment: 'center' },
+        { text: tww ? calculations : '' }
+      ]);
+    }
+  });
+
+  return pdfData;
+}
+const actions: ActionTree<PdfState, RootState> = {
+  setData(
+    { commit }: any,
+    data: { tripId: string; haulId: string; catchId: string }
+  ) {
+    commit('setData', data);
+  },
+  setSpeciesList({ commit }: any, speciesList: any[]) {
+    speciesList.forEach((element) => {
+      speciesMap.set(element.key, element.value.commonName);
+    });
+  },
+  generatePdf({ commit }: any, tallyData: TallyCountData[]) {
+    commit('generatePdf', tallyData);
+  }
+};
+
+const mutations: MutationTree<PdfState> = {
+  setData(
+    newState: any,
+    data: { tripId: string; haulId: string; catchId: string }
+  ) {
+    // Catch, Trip, Haul ID's
+    newState.tripId = data.tripId;
+    newState.haulId = data.haulId;
+    newState.catchId = data.catchId;
+  },
+  generatePdf(newState: any, tallyData: TallyCountData[]) {
+    const date = moment().format();
+    const dateStr = moment().format('MM/DD HH:mm');
+    const tripId = newState.tripId;
+    const haulId = newState.haulId;
+    const catchId = newState.catchId;
+
+    const tallyDataDef = generateTallyPdfData(newState, tallyData);
+
+    const docDefinition = {
+      dateStr,
+      pageSize: 'LETTER',
+      header: (currentPage: number, pageCount: number, pageSize: number) => {
+        return {
+          columns: [
+            { width: 150, bold: true, text: 'FIXED GEAR DECK FORM' },
+            {
+              width: 'auto',
+              text:
+                'TRIP # ' +
+                tripId +
+                '   HAUL # ' +
+                haulId +
+                '   CATCH # ' +
+                catchId
+            },
+            { width: 150, text: `${dateStr}`, alignment: 'right' },
+            {
+              width: 100,
+              text: `Page ${currentPage} of ${pageCount}`,
+              alignment: 'right'
+            }
+          ],
+          margin: [10, 10, 10, 10]
+        };
+      },
+      content: {
+        columns: [
+          {
+            layout: 'lightHorizontalLines', // optional
+            width: 'auto',
+            table: {
+              // headers are automatically repeated if the table spans over multiple pages
+              // you can declare how many rows should be treated as headers
+              headerRows: 1,
+              widths: ['auto', 'auto', 'auto', 'auto', 'auto', 'auto', 'auto'],
+              body: tallyDataDef
+            }
+          }
+        ],
+        margin: [0, 0, 0, 0]
+      }
+    };
+
+    const fileDate = moment().format('YYYYMMDD');
+    pdfMake
+      .createPdf(docDefinition)
+      .download(`tally-${fileDate}-${tripId}-${haulId}.pdf`);
+  }
+};
+
+export const pdfState: Module<PdfState, RootState> = {
+  namespaced: true,
+  state,
+  actions,
+  mutations
+};

--- a/apps/obs-wcgop-optecs/src/_store/tally.module.ts
+++ b/apps/obs-wcgop-optecs/src/_store/tally.module.ts
@@ -763,6 +763,9 @@ const getters: GetterTree<TallyState, RootState> = {
       return getState.tallyDataRec!.data![currentDataIdx].countWeightData;
     }
   },
+  allTallyData(getState: TallyState) {
+    return getState.tallyDataRec!.data;
+  },
   currentTallyData(getState: TallyState) {
     const currentDataIdx = getCurrentDataIndex(getState);
     if (currentDataIdx !== undefined && currentDataIdx >= 0) {

--- a/apps/obs-wcgop-optecs/src/_store/types/types.ts
+++ b/apps/obs-wcgop-optecs/src/_store/types/types.ts
@@ -10,6 +10,12 @@ export interface AlertState {
   message: string | null;
 }
 
+export interface PdfState {
+  tripId?: string;
+  haulId?: string;
+  catchId?: string;
+}
+
 export interface WcgopAppState {
   currentTrip?: WcgopTrip;
   currentHaul?: WcgopOperation;

--- a/apps/obs-wcgop-optecs/src/components/tally/TallyControls.vue
+++ b/apps/obs-wcgop-optecs/src/components/tally/TallyControls.vue
@@ -5,7 +5,7 @@
       Template
       <br>Load/Save
     </tally-control-btn>
-    <q-separator vertical/>
+    <tally-control-btn color="grey-2" text-color="black" control-name="generate-pdf" @controlclick="handleControlClick">Generate<br>PDF</tally-control-btn>
     <tally-control-btn control-name="modify-layout" @controlclick="handleControlClick" color="grey-4" text-color="black">
       Modify
       <br>Layout
@@ -15,7 +15,6 @@
       <br>Mode
       <br>{{tallyMode.incdecText}}
     </tally-control-btn>
-    <q-separator vertical/>
     <tally-control-btn control-name="weights-for" @controlclick="handleControlClick" color="grey-5" text-color="black">
       Weights
       <br>For...

--- a/apps/obs-wcgop-optecs/src/components/tally/TallyHistoryDialog.vue
+++ b/apps/obs-wcgop-optecs/src/components/tally/TallyHistoryDialog.vue
@@ -37,7 +37,7 @@ export default Vue.component('tally-history-dialog', {
           field: 'eventTime',
           align: 'left',
           format: (val: string) => {
-            return moment(val).format('MM/DD hh:mm');
+            return moment(val).format('MM/DD HH:mm');
           }
         },
         {

--- a/apps/obs-wcgop-optecs/src/components/tally/TallyPDFOptionsDialog.vue
+++ b/apps/obs-wcgop-optecs/src/components/tally/TallyPDFOptionsDialog.vue
@@ -1,0 +1,64 @@
+<template>
+  <q-dialog v-model="isOpen" persistent>
+    <q-card style="min-width: 300px">
+      <q-card-section>
+        <div class="text-h6">Generate PDF - Set ID's</div>
+      </q-card-section>
+      <q-card-section>
+        <q-input label="Trip #" v-model.number="config.tripId" type="number"></q-input>
+        <q-input label="Haul #" v-model.number="config.haulId" type="number"></q-input>
+        <q-input label="Catch #" v-model.number="config.catchId" type="number"></q-input>
+      </q-card-section>
+      <q-card-actions align="right" class="text-primary">
+        <q-btn label="Generate PDF" @click="generatePdf" v-close-popup/>
+        <q-btn flat label="Done" @click="close" v-close-popup/>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { TallyHistory } from '../../_store/types';
+import moment from 'moment';
+
+function getReasonClass(val: string) {
+  return 'bg-gray-2';
+}
+
+export default Vue.component('tally-pdf-dialog', {
+  data() {
+    return {
+      isOpen: false,
+      config: {
+        tripId: 0,
+        haulId: 0,
+        catchId: 0
+      }
+    };
+  },
+  methods: {
+    open() {
+      this.isOpen = true;
+    },
+    close() {
+      this.$emit('cancel');
+      this.isOpen = false;
+    },
+    generatePdf() {
+      this.$emit('generatePdf', this.config);
+      this.close();
+    }
+  },
+  computed: {
+    inputsOK(): boolean {
+      console.log('WTF');
+      return (
+        this.config.tripId !== null &&
+        this.config.haulId !== null &&
+        this.config.catchId !== null
+      );
+    }
+  }
+});
+</script>

--- a/apps/obs-wcgop-optecs/src/shims-vue.d.ts
+++ b/apps/obs-wcgop-optecs/src/shims-vue.d.ts
@@ -6,3 +6,6 @@ declare module '*.vue' {
 declare module 'quasar';
 declare module 'vue-touch-keyboard';
 declare module 'pouchdb-utils';
+// https://stackoverflow.com/questions/50576746/import-pdfmake-js-file-to-my-ts-file
+declare module 'pdfmake/build/pdfmake.js';
+declare module 'pdfmake/build/vfs_fonts.js';

--- a/apps/obs-wcgop-optecs/src/views/Hauls.vue
+++ b/apps/obs-wcgop-optecs/src/views/Hauls.vue
@@ -118,7 +118,7 @@ export default class Hauls extends Vue {
           align: 'center',
           label: 'Set Time', // TODO: this needs logic to get first and last
           field: (row: any) =>
-            moment(row.locations[0].date).format('hh:mm MM/DD/YY'),
+            moment(row.locations[0].date).format('HH:mm MM/DD/YY'),
           sortable: true
         },
         {
@@ -126,7 +126,7 @@ export default class Hauls extends Vue {
           align: 'center',
           label: 'Up Time', // TODO: this needs logic to get first and last
           field: (row: any) =>
-            moment(row.locations[1].date).format('hh:mm MM/DD/YY'),
+            moment(row.locations[1].date).format('HH:mm MM/DD/YY'),
           sortable: true
         },
         {

--- a/apps/obs-web/src/views/Debriefer.vue
+++ b/apps/obs-web/src/views/Debriefer.vue
@@ -391,20 +391,16 @@ private async getOperations() {
 
       for (const row of operations.rows) {
         const operation = row.doc;
-        operation.key = row.key;
-        operation.trip = this.WcgopOperationTripDict[operation._id];
 
         for (const locationRow of operation.locations) {
 
-          operation.location = locationRow;
-          console.log(locationRow.position);
-          console.log(operation.location.position);
-          console.log(operation);
-          
-          this.WcgopOperations.push(operation);
+          let opLoc = Object.assign({}, row.doc);
+          opLoc.key = row.key;
+          opLoc.trip = this.WcgopOperationTripDict[operation._id];
+          opLoc.location = locationRow;
+          this.WcgopOperations.push(opLoc);
         }
       }
-      console.log(this.WcgopOperations);
 
   } catch (err) {
       this.error(err);

--- a/apps/obs-web/src/views/Debriefer.vue
+++ b/apps/obs-web/src/views/Debriefer.vue
@@ -391,9 +391,8 @@ private async getOperations() {
 
       for (const row of operations.rows) {
         const operation = row.doc;
-
+        
         for (const locationRow of operation.locations) {
-
           let opLoc = Object.assign({}, row.doc);
           opLoc.key = row.key;
           opLoc.trip = this.WcgopOperationTripDict[operation._id];
@@ -401,6 +400,7 @@ private async getOperations() {
           this.WcgopOperations.push(opLoc);
         }
       }
+
 
   } catch (err) {
       this.error(err);

--- a/apps/obs-web/src/views/Debriefer.vue
+++ b/apps/obs-web/src/views/Debriefer.vue
@@ -1,4 +1,3 @@
-
 <template>
     <div class="q-pa-md">
     <div class="q-gutter-y-md">
@@ -13,7 +12,7 @@
           narrow-indicator
         >
           <q-tab name="trips" label="Trips" />
-          <q-tab name="hauls" label="Hauls" @click="getOperations"/>
+          <q-tab name="operations" label="Hauls" @click="getOperations"/>
           <q-tab name="catch" label="Catch" />
           <q-tab name="catchBaskets" label="Catch Baskets" />
           <q-tab name="specimens" label="Specimens" />
@@ -31,7 +30,7 @@
                               dense
                               row-key="id"
                               :pagination.sync="pagination"
-                              :visible-columns="visibleColumns"
+                              :visible-columns="visibleTripColumns"
                               >
 
                     <template v-slot:top="props">
@@ -39,7 +38,7 @@
                         <div v-if="$q.screen.gt.xs" class="col">
                           <q-select
                             outlined
-                            v-model="visibleColumns"
+                            v-model="visibleTripColumns"
                             multiple
                             :options="tripColumns"
                             label="Visible Columns"
@@ -107,23 +106,106 @@
 
           </q-tab-panel>
 
-          <q-tab-panel name="hauls">
+          <q-tab-panel name="operations">
             <div class="text-h6">Hauls</div>
 
               <q-table
                 :data="WcgopOperations"
-                :columns="haulColumns"
+                :columns="operationColumns"
                 dense
                 row-key="id"
                 :pagination.sync="pagination"
-                >
+                :visible-columns="visibleOperationColumns"
+                              >
+
+                    <template v-slot:top="props">
+
+                        <div v-if="$q.screen.gt.xs" class="col">
+                          <q-select
+                            outlined
+                            v-model="visibleOperationColumns"
+                            multiple
+                            :options="operationColumns"
+                            label="Visible Columns"
+                            style="width: 270px"
+                            option-label="label"
+                            option-value="name"
+                            emit-value
+                            :display-value=null
+                          >
+                          <template v-slot:append>
+                            <q-btn round dense flat style="font-size: .5em" icon="fa fa-plus-circle" @click="addAll" />
+                            <q-btn round dense flat style="font-size: .5em" icon="fa fa-minus-circle" @click="removeAll" />
+                          </template>
+
+                              <template v-slot:option="scope">
+                              <q-item
+                                v-bind="scope.itemProps"
+                                v-on="scope.itemEvents"
+                              >
+                                <q-item-section>
+                                  <q-item-label v-html="scope.opt.label" />
+                                </q-item-section>
+                                <q-item-section avatar v-if="scope.selected">
+                                  <q-icon name="fa fa-check-circle" />
+                                </q-item-section>
+                              </q-item>
+                            </template>
+
+                          </q-select>
+                        </div>
+
+                    </template>
 
                   <template v-slot:body="props">
                     <q-tr :props='props'>
                       <q-td key="key" :props="props">{{ props.row.key }}</q-td>
+                      <q-td key="tripKey" :props="props">{{ props.row.trip.key }}</q-td>
+                      <q-td key="tripStatus" :props="props">{{ props.row.trip.tripStatus.description }}</q-td>
+                      <q-td key="vessel" :props="props">{{ props.row.trip.vessel.vesselName }}</q-td>
+                      <q-td key="program" :props="props">{{ props.row.trip.program.name }}</q-td>
+                      <q-td key="departurePort" :props="props">{{ props.row.trip.departurePort.name }}</q-td>
+                      <q-td key="departureDate" :props="props">{{ formatDate(props.row.trip.departureDate) }}</q-td>
+                      <q-td key="returnPort" :props="props">{{ props.row.trip.returnPort.name }}</q-td>
+                      <q-td key="returnDate" :props="props">{{ formatDate(props.row.trip.returnDate) }}</q-td>
+                      <q-td key="captain" :props="props">{{ props.row.trip.captain }}</q-td>
+                      <q-td key="isPartialTrip" :props="props">{{ props.row.trip.isPartialTrip }}</q-td>
+                      <q-td key="fishingDays" :props="props">{{ props.row.trip.fishingDays }}</q-td>
+                      <q-td key="fishery" :props="props">{{ props.row.trip.fishery ? props.row.trip.fishery.description :'' }}</q-td>
+                      <q-td key="crewSize" :props="props">{{ props.row.trip.crewSize }}</q-td>
+                      <q-td key="firstReceiver" :props="props">{{ props.row.trip.firstReceiver }}</q-td>
+                      <q-td key="isFishProcessed" :props="props">{{ props.row.trip.isFishProcessed }}</q-td>
+                      <q-td key="logbookNum" :props="props">{{ props.row.trip.logbookNum }}</q-td>
+                      <q-td key="logbookType" :props="props">{{ props.row.trip.logbookType }}</q-td>
+                      <q-td key="observerLogbookNum" :props="props">{{ props.row.trip.observerLogbookNum }}</q-td>
+                      <q-td key="debriefer" :props="props">{{ props.row.trip.debriefer }}</q-td>
+                      <q-td key="brd" :props="props">{{ props.row.trip.brd }}</q-td>
+                      <q-td key="hlfc" :props="props">{{ props.row.trip.hlfc }}</q-td>
+                      <q-td key="fishTickets" :props="props">{{ props.row.trip.fishTickets }}</q-td>
+                      <q-td key="certificates" :props="props">{{ props.row.trip.certificates }}</q-td>
+                      <q-td key="waiver" :props="props">{{ props.row.trip.waiver }}</q-td>
+                      <q-td key="intendedGearType" :props="props">{{ props.row.trip.intendedGearType }}</q-td>
                       <q-td key="operationNum" :props="props">{{ props.row.operationNum }}</q-td>
+                      <q-td key="position" :props="props">{{ props.row.location.position }}</q-td>
+                      <q-td key="location" :props="props">{{ props.row.location.location.coordinates[0].toFixed(2) }} {{ props.row.location.location.coordinates[1].toFixed(2) }}</q-td>
                       <q-td key="observerTotalCatch" :props="props">{{ props.row.observerTotalCatch.measurement.value.toFixed(2) }}</q-td>
-
+                      <q-td key="gearType" :props="props">{{ props.row.gearType.description }}</q-td>
+                      <q-td key="gearPerformance" :props="props">{{ props.row.gearPerformance.description }}</q-td>
+                      <q-td key="targetStrategy" :props="props">{{ props.row.targetStrategy }}</q-td>
+                      <q-td key="isEfpUsed" :props="props">{{ props.row.isEfpUsed }}</q-td>
+                      <q-td key="calWeight" :props="props">{{ props.row.calWeight }}</q-td>
+                      <q-td key="fit" :props="props">{{ props.row.fit }}</q-td>
+                      <q-td key="isGearLost" :props="props">{{ props.row.isGearLost }}</q-td>
+                      <q-td key="isDataQualityPassing" :props="props">{{ props.row.isDataQualityPassing }}</q-td>
+                      <q-td key="beaufortValue" :props="props">{{ props.row.beaufortValue }}</q-td>
+                      <q-td key="isDeterrentUsed" :props="props">{{ props.row.isDeterrentUsed }}</q-td>
+                      <q-td key="excluderType" :props="props">{{ props.row.legacy.excluderType }}</q-td>
+                      <q-td key="avgSoakTime" :props="props">{{ props.row.avgSoakTime }}</q-td>
+                      <q-td key="totalHooks" :props="props">{{ props.row.totalHooks }}</q-td>
+                      <q-td key="totalHooksLost" :props="props">{{ props.row.totalHooksLost }}</q-td>
+                      <q-td key="totalGearSegments" :props="props">{{ props.row.totalGearSegments }}</q-td>
+                      <q-td key="gearSegmentsLost" :props="props">{{ props.row.gearSegmentsLost }}</q-td>
+                      <q-td key="hooksSampled" :props="props">{{ props.row.hooksSampled }}</q-td>
                     </q-tr>
                   </template>
 
@@ -181,10 +263,14 @@ export default class Debriefer extends Vue {
   @Action('error', { namespace: 'alert' }) private error: any;
 
 private WcgopTrips: WcgopTrip[] = [];
+private WcgopOperationTripDict: any = {};
 private WcgopOperations: WcgopOperation[] = [];
 private pagination = {rowsPerPage: 50};
-private visibleColumns = ['key', 'tripStatus', 'vessel'];
-private selectedColumns = [];
+private visibleTripColumns = ['key', 'tripStatus', 'vessel','program','departurePort','departureDate','returnPort','returnDate'];
+private visibleOperationColumns = ['tripKey', 'operationNum','position','location','observerTotalCatch','gearType','gearPerformance','targetStrategy',
+  'isEfpUsed','calWeight','fit','isGearLost','isDataQualityPassing','beaufortValue','isDeterrentUsed','excluderType','avgSoakTime',
+  'totalHooks','totalHooksLost','totalGearSegments','gearSegmentsLost','hooksSampled'];
+
 private tab = 'trips';
 private tripColumns = [
     {name: 'key', label: 'Trip ID', field: 'key', align: 'left', sortable: true },
@@ -214,10 +300,53 @@ private tripColumns = [
     {name: 'intendedGearType', label: 'Intended Gear Type', field: 'intendedGearType', align: 'left', sortable: true }
 ];
 
-private haulColumns = [
-    {name: 'key', label: 'Haul ID', field: 'key', align: 'left', sortable: true },
+private operationColumns = [
+   // {name: 'key', label: 'Haul ID', field: 'key', align: 'left', sortable: true },
+    {name: 'tripKey', label: 'Trip ID', field: 'tripKey', align: 'left', sortable: true },
+    {name: 'tripStatus', label: 'Trip Status', field: 'tripStatus', align: 'left', sortable: true },
+    {name: 'vessel', label: 'Vessel', field: 'vessel', align: 'left', sortable: true },
+    {name: 'program', label: 'Program', field: 'program', align: 'left', sortable: true },
+    {name: 'departurePort', label: 'Departure Port', field: 'departurePort', align: 'left', sortable: true },
+    {name: 'departureDate', label: 'Departure Date', field: 'departureDate', align: 'left', sortable: true },
+    {name: 'returnPort', label: 'Return Port', field: 'returnPort', align: 'left', sortable: true },
+    {name: 'returnDate', label: 'Return Date', field: 'returnDate', align: 'left', sortable: true },
+    {name: 'captain', label: 'Skipper', field: 'captain', align: 'left', sortable: true },
+    {name: 'isPartialTrip', label: 'Partial Trip', field: 'isPartialTrip', align: 'left', sortable: true },
+    {name: 'fishingDays', label: 'Fishing Days', field: 'fishingDays', align: 'left', sortable: true },
+    {name: 'fishery', label: 'Fishery', field: 'fishery', align: 'left', sortable: true },
+    {name: 'crewSize', label: 'Crew Size', field: 'crewSize', align: 'left', sortable: true },
+    {name: 'firstReceiver', label: 'First Receiver', field: 'firstReceiver', align: 'left', sortable: true },
+    {name: 'isFishProcessed', label: 'Fish Processed', field: 'isFishProcessed', align: 'left', sortable: true },
+    {name: 'logbookNum', label: 'Logbook #', field: 'logbookNum', align: 'left', sortable: true },
+    {name: 'logbookType', label: 'Logbook Type', field: 'logbookType', align: 'left', sortable: true },
+    {name: 'observerLogbookNum', label: 'Observer Logbook', field: 'observerLogbookNum', align: 'left', sortable: true },
+    {name: 'debriefer', label: 'Debriefer', field: 'debriefer', align: 'left', sortable: true },
+    {name: 'brd', label: 'BRD', field: 'brd', align: 'left', sortable: true },
+    {name: 'hlfc', label: 'HLFC', field: 'hlfc', align: 'left', sortable: true },
+    {name: 'fishTickets', label: 'Fish Tickets', field: 'fishTickets', align: 'left', sortable: true },
+    {name: 'certificates', label: 'Certificates', field: 'certificates', align: 'left', sortable: true },
+    {name: 'waiver', label: 'Waiver', field: 'waiver', align: 'left', sortable: true },
+    {name: 'intendedGearType', label: 'Intended Gear Type', field: 'intendedGearType', align: 'left', sortable: true },
     {name: 'operationNum', label: 'Haul #', field: 'operationNum', align: 'left', sortable: true },
-    {name: 'observerTotalCatch', label: 'OTC', field: 'observerTotalCatch', align: 'left', sortable: true }
+    {name: 'position', label: 'Position', field: 'position', align: 'left', sortable: true },
+    {name: 'location', label: 'Location', field: 'location', align: 'left', sortable: true },
+    {name: 'observerTotalCatch', label: 'OTC', field: 'observerTotalCatch', align: 'left', sortable: true },
+    {name: 'gearType', label: 'Gear Type', field: 'gearType', align: 'left', sortable: true },
+    {name: 'gearPerformance', label: 'Gear Performance', field: 'gearPerformance', align: 'left', sortable: true },
+    {name: 'targetStrategy', label: 'Target Strategy', field: 'targetStrategy', align: 'left', sortable: true },
+    {name: 'isEfpUsed', label: 'EFP', field: 'isEfpUsed', align: 'left', sortable: true },
+    {name: 'calWeight', label: 'CAL Weight', field: 'calWeight', align: 'left', sortable: true },
+    {name: 'fit', label: 'Fit', field: 'fit', align: 'left', sortable: true },
+    {name: 'isGearLost', label: 'Gear Lost', field: 'isGearLost', align: 'left', sortable: true },
+    {name: 'isDataQualityPassing', label: 'DQ Passed', field: 'isDataQualityPassing', align: 'left', sortable: true },
+    {name: 'beaufortValue', label: 'Beaufort', field: 'beaufortValue', align: 'left', sortable: true },
+    {name: 'isDeterrentUsed', label: 'Deterrent Used', field: 'isDeterrentUsed', align: 'left', sortable: true },
+    {name: 'avgSoakTime', label: 'Avg Soak Time', field: 'avgSoakTime', align: 'left', sortable: true },
+    {name: 'totalHooks', label: 'Total Hooks', field: 'totalHooks', align: 'left', sortable: true },
+    {name: 'totalHooksLost', label: 'Excluder', field: 'totalHooksLost', align: 'left', sortable: true },
+    {name: 'totalGearSegments', label: 'Total Gear Segments', field: 'totalGearSegments', align: 'left', sortable: true },
+    {name: 'gearSegmentsLost', label: 'Gear Segments Lost', field: 'gearSegmentsLost', align: 'left', sortable: true },
+    {name: 'hooksSampled', label: 'Hooks Sampled', field: 'hooksSampled', align: 'left', sortable: true }
 ];
 
 private async getTrips() {
@@ -234,9 +363,12 @@ private async getTrips() {
           );
 
       for (const row of trips.rows) {
-          const trip = row.doc;
-          trip.key = row.key;
-          this.WcgopTrips.push(trip);
+        const trip = row.doc;
+        trip.key = row.key;
+        this.WcgopTrips.push(trip);
+
+        for (const operationId of trip.operationIDs) 
+          this.WcgopOperationTripDict[operationId] = trip;
       }
 
   } catch (err) {
@@ -248,20 +380,32 @@ private async getOperations() {
   const masterDB: Client<any> = couchService.masterDB;
   try {
       const options: ListOptions = {
-        limit: 20
+        keys: Object.keys(this.WcgopOperationTripDict)
       };
 
-      const hauls = await masterDB.viewWithDocs<any>(
+      const operations = await masterDB.viewWithDocs<any>(
           'MainDocs',
           'all-operations',
           options
           );
 
-      for (const row of hauls.rows) {
-          const haul = row.doc;
-          haul.key = row.key;
-          this.WcgopOperations.push(haul);
+      for (const row of operations.rows) {
+        const operation = row.doc;
+        operation.key = row.key;
+        operation.trip = this.WcgopOperationTripDict[operation._id];
+
+        for (const locationRow of operation.locations) {
+
+          operation.location = locationRow;
+          console.log(locationRow.position);
+          console.log(operation.location.position);
+          console.log(operation);
+          
+          this.WcgopOperations.push(operation);
+        }
       }
+      console.log(this.WcgopOperations);
+
   } catch (err) {
       this.error(err);
   }
@@ -277,11 +421,11 @@ private formatDate(inputDate: any) {
 }
 
 private addAll() {
-  this.visibleColumns = this.tripColumns.map( (tripColumns) => tripColumns.name);
+  this.visibleTripColumns = this.tripColumns.map( (tripColumns) => tripColumns.name);
 }
 
 private removeAll() {
-  this.visibleColumns = [];
+  this.visibleTripColumns = [];
 }
 
 

--- a/libs/bn-util/index.ts
+++ b/libs/bn-util/index.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 export function shortFormatDate(dateStr: string): string {
-  return moment(dateStr).format('MM/DD/YY hh:mm');
+  return moment(dateStr).format('MM/DD/YY HH:mm');
 }
 
 export function formatDate(dateStr: string): string {


### PR DESCRIPTION
@sethgerou-noaa  please review how I associated hauls/trips.

@wsmith-nwfsc / @toddhay-NOAA / @sethgerou-noaa 
1) For the debriefing hauls tab, I had to associate each haul with a trip through code which made me change the all-operations view from:

```
function (doc) {
  if (doc.type == 'wcgop-operation') { 
    emit(doc.legacy.fishingActivityId, doc._rev);
  }
}
```

to

```
function (doc) {
  if (doc.type == 'wcgop-operation') { 
    emit(doc._id, doc._rev);
  }
}
```

Hope that's ok...as I had to do a weird query, see `keys: Object.keys(this.WcgopOperationTripDict)`
Not sure if this is the best approach.


2) For each location within a haul, we need a row in the hauls tab so I added a second loop within the operations loop (that's row 397.... `for (const locationRow of operation.locations)`). As you can see with the screenshot below, the positions are all -1 however somehow they change to 0, so there's some weird thing going on where a negative number gets changed to 0. Any thoughts? Row 400-402 in the debriefer.vue.

<img width="1351" alt="debug" src="https://user-images.githubusercontent.com/20570382/58754557-a0847f00-8487-11e9-92a9-ec5ec2f3906f.png">
