### PR TITLE
Rollforward to pouch-vue v0.3.4 and other fixes

### DIFF
--- a/apps/obs-wcgop-optecs/package.json
+++ b/apps/obs-wcgop-optecs/package.json
@@ -21,7 +21,7 @@
     "davenport": "^2.8.2",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.25",
-    "pouch-vue": "^0.1.37",
+    "pouch-vue": "^0.3.4",
     "pouchdb-authentication": "^1.1.3",
     "pouchdb-browser": "^7.0.0",
     "quasar": "^1.0.0-rc.4",

--- a/apps/obs-web/package.json
+++ b/apps/obs-web/package.json
@@ -24,7 +24,7 @@
     "davenport": "^2.8.2",
     "geojson": "^0.5.0",
     "moment": "^2.24.0",
-    "pouch-vue": "^0.1.37",
+    "pouch-vue": "^0.3.4",
     "pouchdb-authentication": "^1.1.3",
     "pouchdb-browser": "^7.0.0",
     "quasar": "^1.0.0-rc.4",

--- a/libs/bn-pouch/package.json
+++ b/libs/bn-pouch/package.json
@@ -15,7 +15,7 @@
     "davenport": "^2.8.2",
     "jsonwebtoken": "^8.5.1",
     "pem-jwk": "^2.0.0",
-    "pouch-vue": "^0.1.37",
+    "pouch-vue": "^0.3.4",
     "pouchdb-authentication": "^1.1.3",
     "pouchdb-browser": "^7.0.0",
     "pouchdb-find": "^7.0.0",

--- a/libs/bn-pouch/src/_services/pouch.service.ts
+++ b/libs/bn-pouch/src/_services/pouch.service.ts
@@ -16,7 +16,6 @@ PouchDB.plugin(pa);
 
 Vue.use(PouchVue, {
   pouch: PouchDB
-  }  
 });
 
 import { CouchDBCredentials } from '@boatnet/bn-couch';

--- a/libs/bn-pouch/src/_services/pouch.service.ts
+++ b/libs/bn-pouch/src/_services/pouch.service.ts
@@ -16,6 +16,12 @@ PouchDB.plugin(pa);
 
 Vue.use(PouchVue, {
   pouch: PouchDB,
+  optionsDB: {
+    fetch: function (url:any, opts:any) {
+        opts.credentials = 'include';
+      return PouchDB.fetch(url, opts);
+      }    
+  }  
 });
 
 import { CouchDBCredentials } from '@boatnet/bn-couch';

--- a/libs/bn-pouch/src/_services/pouch.service.ts
+++ b/libs/bn-pouch/src/_services/pouch.service.ts
@@ -15,12 +15,7 @@ PouchDB.plugin(plf);
 PouchDB.plugin(pa);
 
 Vue.use(PouchVue, {
-  pouch: PouchDB,
-  optionsDB: {
-    fetch: function (url:any, opts:any) {
-        opts.credentials = 'include';
-      return PouchDB.fetch(url, opts);
-      }    
+  pouch: PouchDB
   }  
 });
 

--- a/libs/bn-pouch/src/_services/pouch.service.ts
+++ b/libs/bn-pouch/src/_services/pouch.service.ts
@@ -148,17 +148,10 @@ class PouchService extends Vue {
     this.$emit('syncCompleted', initialSyncRO);
 
     this.$pouch
-      .sync(credentials.dbInfo.userDB, credentialedUserDB, syncOptsLive)
-      .on('paused', (err: any) => {
-        // weird logic in pouch-vue, so handling this here
-        this.syncDeactive({});
-      });
+      .sync(credentials.dbInfo.userDB, credentialedUserDB, syncOptsLive);
+      
     this.$pouch
-      .sync(credentials.dbInfo.lookupsDB, credentialedReadOnlyDB, syncOptsLive)
-      .on('paused', (err: any) => {
-        // weird logic in pouch-vue, so handling this here
-        this.syncDeactive({});
-      });
+      .sync(credentials.dbInfo.lookupsDB, credentialedReadOnlyDB, syncOptsLive);
 
     console.log('[PouchDB Service] Live sync enabled.');
   }

--- a/libs/bn-pouch/src/_services/pouch.service.ts
+++ b/libs/bn-pouch/src/_services/pouch.service.ts
@@ -7,7 +7,7 @@ import PouchDB from 'pouchdb-browser';
 import lf from 'pouchdb-find';
 import plf from 'pouchdb-live-find';
 import pa from 'pouchdb-authentication';
-import PouchVue, { PouchAPI } from 'pouch-vue';
+import PouchVue from 'pouch-vue';
 
 // PouchDB plugins: pouchdb-find (included in the monorepo), LiveFind (external plugin), and couchdb auth
 PouchDB.plugin(lf);

--- a/libs/bn-pouch/src/_services/pouch.service.ts
+++ b/libs/bn-pouch/src/_services/pouch.service.ts
@@ -3,40 +3,19 @@
 /* tslint:disable:no-console  */
 /* tslint:disable:no-var-requires  */
 import { Component, Vue, Prop } from 'vue-property-decorator';
-// @ts-ignore
 import PouchDB from 'pouchdb-browser';
-// @ts-ignore
 import lf from 'pouchdb-find';
-// @ts-ignore
 import plf from 'pouchdb-live-find';
-// @ts-ignore
 import pa from 'pouchdb-authentication';
-// @ts-ignore
-import PouchVue, { PublicPouchVueMethods } from 'pouch-vue';
+import PouchVue, { PouchAPI } from 'pouch-vue';
 
 // PouchDB plugins: pouchdb-find (included in the monorepo), LiveFind (external plugin), and couchdb auth
 PouchDB.plugin(lf);
 PouchDB.plugin(plf);
 PouchDB.plugin(pa);
 
-// https://vuejs.org/v2/guide/typescript.html#Augmenting-Types-for-Use-with-Plugins
-declare module 'vue/types/vue' {
-  // Declare augmentation for Vue
-  interface Vue {
-    // @ts-ignore
-    $pouch: PublicPouchVueMethods; // optional if `PouchDB` is available on the global object
-    $defaultDB: string; // the database to use if none is specified in the pouch setting of the vue component
-  }
-}
-
-declare module 'vue/types/options' {
-  interface ComponentOptions<V extends Vue> {
-    pouch?: any; // this is where the database will be reactive
-  }
-}
-
 Vue.use(PouchVue, {
-  pouch: PouchDB
+  pouch: PouchDB,
 });
 
 import { CouchDBCredentials } from '@boatnet/bn-couch';

--- a/libs/bn-pouch/src/_store/pouch.module.ts
+++ b/libs/bn-pouch/src/_store/pouch.module.ts
@@ -33,6 +33,7 @@ const actions: ActionTree<PouchDBState, any> = {
   // Mutations are asynchronous
   async connect({ commit }: any, credentials: CouchDBCredentials) {
     activateSyncListener( commit );
+    await pouchService.connect(credentials);
     commit('connectRequest', credentials);
   },
   async reconnect({ commit }: any) {
@@ -54,7 +55,6 @@ const actions: ActionTree<PouchDBState, any> = {
 const mutations: MutationTree<PouchDBState> = {
   // Mutations must by synchronous
   connectRequest(newState: PouchDBState, credentials: CouchDBCredentials) {
-    pouchService.connect(credentials);
     newState.credentials = credentials;
   },
   reconnectRequest(newState: PouchDBState) {


### PR DESCRIPTION
Hello,

I've been collaborating on the [pouch-vue project](https://github.com/MDSLKTR/pouch-vue) and started taking a look at your boatnet project which is very well done. I like the structure of how you're using pouch in your PWA with the vuex modules and the service layer so I have been testing it out in my own PWA project. This PR is a copy&paste of what is working for me in my own project since I'm not actually developing on your repo, just using it for ideas. So I've included a number of fixes which hopefully are of use to your project and compile properly.

In pouch-vue v0.3.4, we have fixed a bug with the 'paused' event in pouchdb sync that I think was being alluded to in your code here:

https://github.com/nwfsc-fram/boatnet/blob/a79f4f47aa7d2b9f4ef67f53b2bd3c00be16ee32/libs/bn-pouch/src/_services/pouch.service.ts#L150-L161

So I went ahead and remove your workaround for the bug after rolling forward the version of pouch-vue that boatnet uses to v0.3.4 which has a fix for the bug and is the latest version.

I also cleaned up the typescript a bit since there's been changes to interface names in pouch-vue and the plugin pouchdb-live-find now has its own typings on DefinitelyTyped as well, so no need for the @ts-ignore comments anymore.

I've seen a few comments about authentication issues that Boatnet has had:

https://github.com/nwfsc-fram/boatnet/blob/c1146306cd959ac824dfa5e2a02915f68b035417/libs/bn-pouch/src/_services/pouch.service.ts#L84

For me these were fixed by overriding the fetch method and so I've included that commit as well.

In the Vuex store for the pouch module I moved the async connect methods out of the mutations section and into the actions section where I think they belong.

I've included detailed comments with each of the commits. Let me know what you think.

Thanks for sharing your work on github. It's been very interesting to go through!