### PR TITLE
Fix typescript warnings for taxonomy

### DIFF
--- a/libs/bn-models/models/_lookups/fishing-area.ts
+++ b/libs/bn-models/models/_lookups/fishing-area.ts
@@ -1,10 +1,10 @@
-import { MultiLineString } from "geojson";
+import { MultiLineString } from 'geojson';
 
 export const FishingAreaTypeName = 'fishing-area';
 
 // Source - OBSPROD.LOOKUPS.FISHING_AREA
 export interface FishingArea {
-  label: number;  // 100, 200, 300, 400
+  label: number; // 100, 200, 300, 400
   description: string;
   geography: MultiLineString; // Top + Bottom latitude lines
 }

--- a/libs/bn-models/models/_lookups/management-area.ts
+++ b/libs/bn-models/models/_lookups/management-area.ts
@@ -1,30 +1,30 @@
-import { Base } from "../_base";
-import { BoatnetDate } from "../_common";
-import { CatchGrouping } from "./catch-grouping";
-import { TaxonomyAlias } from "./taxonomy-alias";
-import { FishingArea } from "./fishing-area";
+import { Base } from '../_base';
+import { BoatnetDate } from '../_common';
+import { CatchGrouping } from './catch-grouping';
+import { TaxonomyAlias } from './taxonomy-alias';
+import { FishingArea } from './fishing-area';
 
 declare type ManagementType = string; // TODO - lookup - IFQ, FMP, etc.
 export const ManagementAreaTypeName = 'management-area';
 
 // Source - OBSPROD.IFQ_SPECIE_GROUPINGS
 export interface ManagementArea extends Base {
-    name: string; // possibly a concatenation of year + area for this
-    year: BoatnetDate;
-    area: FishingArea;  // 2 lines only per management area
-    managementType: ManagementType;
+  name: string; // possibly a concatenation of year + area for this
+  year: BoatnetDate;
+  area: FishingArea; // 2 lines only per management area
+  managementType: ManagementType;
 
-    // Consider making TaxonomyAlias an array
-    // i.e. it could be 2018, area = 200, and have arrowtooth + petrale
-    // How is a management area uniquely defined?
-    //  -- year + area combination?
-    //  -- year + area + members combination?
+  // Consider making TaxonomyAlias an array
+  // i.e. it could be 2018, area = 200, and have arrowtooth + petrale
+  // How is a management area uniquely defined?
+  //  -- year + area combination?
+  //  -- year + area + members combination?
 
-    // Need to see how the expansion code is using this
-    // Idea is:  for this area for a given year, expand all of these members
-    // may or may not want to allow an array of members below, but rather 
-    // just have a CatchGrouping | TaxonomyAlias
-    members: (CatchGrouping | TaxonomyAlias)[];
+  // Need to see how the expansion code is using this
+  // Idea is:  for this area for a given year, expand all of these members
+  // may or may not want to allow an array of members below, but rather
+  // just have a CatchGrouping | TaxonomyAlias
+  members: Array<CatchGrouping | TaxonomyAlias>;
 }
 
 /*

--- a/libs/bn-models/models/_lookups/species-category.ts
+++ b/libs/bn-models/models/_lookups/species-category.ts
@@ -6,7 +6,7 @@ import { Taxonomy } from './taxonomy';
 export const SpeciesCategoryTypeName = 'species-category';
 
 // Source - OBSPROD.SPECIES_SUB_CATEGORY
-declare type SpeciesSubCategory = {
+declare interface SpeciesSubCategory {
   name: string;
   taxonomy: Taxonomy;
 }
@@ -14,7 +14,7 @@ declare type SpeciesSubCategory = {
 // Source - OBSPROD.SPECIES_CATEGORY
 export interface SpeciesCategory extends Base {
   description?: string;
-  taxonomy?: Taxonomy;  // Beth to track down
+  taxonomy?: Taxonomy; // Beth to track down
   subCategories?: SpeciesSubCategory[]; // Beth to track down
 
   legacy?: {


### PR DESCRIPTION
Fixes the following:
```
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/fishing-area.ts
1:33 " should be '
  > 1 | import { MultiLineString } from "geojson";
      |                                 ^
    2 | 
    3 | export const FishingAreaTypeName = 'fishing-area';
    4 | 
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/fishing-area.ts
10:2 file should end with a newline
     8 |   description: string;
     9 |   geography: MultiLineString; // Top + Bottom latitude lines
  > 10 | }
       |  ^
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/management-area.ts
1:22 " should be '
  > 1 | import { Base } from "../_base";
      |                      ^
    2 | import { BoatnetDate } from "../_common";
    3 | import { CatchGrouping } from "./catch-grouping";
    4 | import { TaxonomyAlias } from "./taxonomy-alias";
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/management-area.ts
2:29 " should be '
    1 | import { Base } from "../_base";
  > 2 | import { BoatnetDate } from "../_common";
      |                             ^
    3 | import { CatchGrouping } from "./catch-grouping";
    4 | import { TaxonomyAlias } from "./taxonomy-alias";
    5 | import { FishingArea } from "./fishing-area";
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/management-area.ts
3:31 " should be '
    1 | import { Base } from "../_base";
    2 | import { BoatnetDate } from "../_common";
  > 3 | import { CatchGrouping } from "./catch-grouping";
      |                               ^
    4 | import { TaxonomyAlias } from "./taxonomy-alias";
    5 | import { FishingArea } from "./fishing-area";
    6 | 
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/management-area.ts
4:31 " should be '
    2 | import { BoatnetDate } from "../_common";
    3 | import { CatchGrouping } from "./catch-grouping";
  > 4 | import { TaxonomyAlias } from "./taxonomy-alias";
      |                               ^
    5 | import { FishingArea } from "./fishing-area";
    6 | 
    7 | declare type ManagementType = string; // TODO - lookup - IFQ, FMP, etc.
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/management-area.ts
5:29 " should be '
    3 | import { CatchGrouping } from "./catch-grouping";
    4 | import { TaxonomyAlias } from "./taxonomy-alias";
  > 5 | import { FishingArea } from "./fishing-area";
      |                             ^
    6 | 
    7 | declare type ManagementType = string; // TODO - lookup - IFQ, FMP, etc.
    8 | export const ManagementAreaTypeName = 'management-area';
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/management-area.ts
25:74 trailing whitespace
    23 |     // Need to see how the expansion code is using this
    24 |     // Idea is:  for this area for a given year, expand all of these members
  > 25 |     // may or may not want to allow an array of members below, but rather 
       |                                                                          ^
    26 |     // just have a CatchGrouping | TaxonomyAlias
    27 |     members: (CatchGrouping | TaxonomyAlias)[];
    28 | }
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/management-area.ts
27:14 Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
    25 |     // may or may not want to allow an array of members below, but rather 
    26 |     // just have a CatchGrouping | TaxonomyAlias
  > 27 |     members: (CatchGrouping | TaxonomyAlias)[];
       |              ^
    28 | }
    29 | 
    30 | /*
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/species-category.ts
9:14 Use an interface instead of a type literal.
     7 | 
     8 | // Source - OBSPROD.SPECIES_SUB_CATEGORY
  >  9 | declare type SpeciesSubCategory = {
       |              ^
    10 |   name: string;
    11 |   taxonomy: Taxonomy;
    12 | }
WARNING in C:/git/boatnet/node_modules/@boatnet/bn-models/models/_lookups/species-category.ts
12:2 Missing semicolon
    10 |   name: string;
    11 |   taxonomy: Taxonomy;
  > 12 | }
```