### PR TITLE
ots:

### DIFF
--- a/apps/obs-web/vue.config.js
+++ b/apps/obs-web/vue.config.js
@@ -12,8 +12,8 @@ module.exports = {
     workboxPluginMode: 'InjectManifest',
     workboxOptions: {
       swSrc: 'service-worker.js',
-      skipWaiting: true,
-      clientsClaim: true,
+      // skipWaiting: true,
+      // clientsClaim: true,
     }
   },
   transpileDependencies: [/[\\\/]node_modules[\\\/]quasar[\\\/]/],


### PR DESCRIPTION
Disabling workbox skipWaiting and clientsClaim in vue.config.js.
Functions are still present in service-worker.js.