### PR TITLE
Upgrading to bn-pouch 0.2.0

### DIFF
--- a/apps/ashop/package.json
+++ b/apps/ashop/package.json
@@ -12,7 +12,7 @@
     "@boatnet/bn-common": "file:..\\..\\libs\\bn-common",
     "@boatnet/bn-couch": "^0.1.6",
     "@boatnet/bn-models": "^0.1.6",
-    "@boatnet/bn-pouch": "^0.1.5",
+    "@boatnet/bn-pouch": "^0.2.0",
     "@boatnet/bn-util": "^0.1.1",
     "@quasar/extras": "^1.0.0",
     "@types/lodash": "^4.14.144",

--- a/apps/ashop/src/helpers/cruiseInfo.ts
+++ b/apps/ashop/src/helpers/cruiseInfo.ts
@@ -35,10 +35,10 @@ export async function getTrips() {
 export function updateCruise(tripId: CouchID) {
     if (cruise) {
         cruise.trips ? cruise.trips.push(tripId) : (cruise.trips = [tripId]);
-        db.put(pouchService.userDBName, cruise);
+        db.put(cruise);
     } else {
         const newCruise = { type: 'ashop-cruise', trips: [tripId] };
-        db.post(pouchService.userDBName, newCruise);
+        db.post(newCruise);
     }
 }
 
@@ -46,7 +46,7 @@ export function deleteCruise(tripId: CouchID) {
     if (cruise.trips) {
         remove(cruise.trips, (n: string) => n === tripId);
     }
-    db.put(pouchService.userDBName, cruise).then((response: any) => {
+    db.put(cruise).then((response: any) => {
         cruise._id = response.id;
         cruise._rev = response.rev;
     });

--- a/apps/ashop/src/helpers/cruiseInfo.ts
+++ b/apps/ashop/src/helpers/cruiseInfo.ts
@@ -19,7 +19,6 @@ export async function getTrips() {
     };
     try {
         const result = await db.allDocs(
-            pouchService.userDBName,
             queryOptions
         );
         return result.rows;

--- a/apps/ashop/src/views/Hauls.vue
+++ b/apps/ashop/src/views/Hauls.vue
@@ -107,7 +107,6 @@ export default class Hauls extends Vue {
 
   private async getHauls() {
     const currTrip = await pouchService.db.get(
-      pouchService.userDBName,
       this.currentTrip._id
     );
     if (currTrip.operationIDs) {
@@ -117,7 +116,6 @@ export default class Hauls extends Vue {
       };
       try {
         const result = await pouchService.db.allDocs(
-          pouchService.userDBName,
           queryOptions
         );
         this.haulsData = result.rows;

--- a/apps/ashop/src/views/Hauls.vue
+++ b/apps/ashop/src/views/Hauls.vue
@@ -158,7 +158,7 @@ export default class Hauls extends Vue {
       this.haulsData.length > 0 ? parseInt(this.haulsData[0].doc[this.haulsSettings.itemNumName], 10) + 1 : 1;
 
     await pouchService.db
-      .post(pouchService.userDBName, haul)
+      .post(haul)
       .then((response: any) => {
         haul._id = response.id;
         haul._rev = response.rev;
@@ -188,7 +188,7 @@ export default class Hauls extends Vue {
       remove(this.currentTrip.operationIDs, (n: string) => n === this.currentHaul._id);
       this.save(this.currentTrip);
     }
-    await pouchService.db.remove(pouchService.userDBName, this.currentHaul);
+    await pouchService.db.remove(this.currentHaul);
     this.setCurrentHaul(undefined);
   }
 

--- a/apps/ashop/src/views/NonFishingDay.vue
+++ b/apps/ashop/src/views/NonFishingDay.vue
@@ -20,7 +20,6 @@
 <script lang="ts">
 import { createComponent, ref, reactive, computed } from '@vue/composition-api';
 import { WcgopTrip } from '@boatnet/bn-models';
-import { pouchService, pouchState, PouchDBState } from '@boatnet/bn-pouch';
 import { set } from 'lodash';
 
 export default createComponent({

--- a/apps/ashop/src/views/Trips.vue
+++ b/apps/ashop/src/views/Trips.vue
@@ -81,7 +81,7 @@ export default createComponent({
       const type: string = appMode + '-trip';
       const trip: BaseTrip = { tripNum, type };
       await pouchService.db
-        .post(pouchService.userDBName, trip)
+        .post(trip)
         .then((response: any) => {
           trip._id = response.id;
           trip._rev = response.rev;
@@ -105,10 +105,7 @@ export default createComponent({
       }
       const del = data.value.findIndex((i: any) => i.id === id);
       data.value.splice(del, 1);
-      pouchService.db.remove(
-        pouchService.userDBName,
-        store.state.tripsState.currentTrip
-      );
+      pouchService.db.remove(store.state.tripsState.currentTrip);
       store.dispatch('tripsState/setCurrentTrip', undefined);
     };
 

--- a/apps/ashop/src/views/Trips.vue
+++ b/apps/ashop/src/views/Trips.vue
@@ -65,7 +65,7 @@ export default createComponent({
     });
 
     const init = async () => {
-      const docs = await db.allDocs(pouchService.userDBName);
+      const docs = await db.allDocs();
       const rows = docs.rows;
       if (appMode === 'ashop') {
         await getCruise(appMode, rows);

--- a/libs/bn-common/src/_store/appSettings.module.ts
+++ b/libs/bn-common/src/_store/appSettings.module.ts
@@ -55,9 +55,9 @@ const mutations: MutationTree<AppSettings> = {
         include_docs: true
       };
       const config = await db.query(
-        pouchService.lookupsDBName,
         'LookupDocs/boatnet-config-lookup',
-        queryOptions
+        queryOptions,
+        pouchService.lookupsDBName
       );
       newState.appConfig = config.rows[0].doc;
     } catch (err) {

--- a/libs/bn-common/src/_store/trips.module.ts
+++ b/libs/bn-common/src/_store/trips.module.ts
@@ -35,7 +35,7 @@ const mutations: MutationTree<TripState> = {
     try {
       if (record._id) {
         pouchService.db
-          .put(pouchService.userDBName, record)
+          .put(record)
           .then((response: any) => {
             record._rev = response.rev;
           });

--- a/libs/bn-common/src/components/BoatnetKeyboardList.vue
+++ b/libs/bn-common/src/components/BoatnetKeyboardList.vue
@@ -58,9 +58,9 @@ export default class BoatnetKeyboardList extends Vue {
     };
 
     const results = await pouchDB.query(
-      pouchService.lookupsDBName,
       'obs_web/all_doc_types',
-      queryOptions
+      queryOptions,
+      pouchService.lookupsDBName
     );
     console.log(results);
     const resultList = [];


### PR DESCRIPTION
The newest vue-pouch version changed the order of arguments so the current queries need to be modified in order to work with the new update.

Old Version [documentation](https://www.npmjs.com/package/pouch-vue/v/0.1.37)
New Version [documentation](https://www.npmjs.com/package/pouch-vue/v/0.3.5)

https://github.com/nwfsc-fram/boatnet/issues/1152