### PR TITLE
fixing bugs and adding view to doc type on userDB

### DIFF
--- a/apps/ashop/src/data/initHauls.ts
+++ b/apps/ashop/src/data/initHauls.ts
@@ -1,10 +1,21 @@
-import { AshopHaul, Measurement, WcgopOperation } from '@boatnet/bn-models';
+import { AshopHaul, Measurement, WcgopOperation, BaseOperation } from '@boatnet/bn-models';
 import { initMeasurement } from '@boatnet/bn-models';
 
-export function update(haul: AshopHaul) {
+export function update(haul: AshopHaul, fieldName: string) {
     haul.officialTotalCatch = setOfficialTotalCatch(haul);
+    // apply depth units to both fishing and bottom depth
     if (haul.fishingDepth) {
         haul.fishingDepth.units = haul.bottomDepth ? haul.bottomDepth.units : '';
+    }
+    setFishingLocationUnits(haul, fieldName);
+}
+
+// set startFishingLocation units and endFishingLocation units equal to each other
+function setFishingLocationUnits(haul: BaseOperation, fieldName: string) {
+    if (fieldName === 'startFishingLocation') {
+        haul.endFishingLocation.unit = haul.startFishingLocation.unit;
+    } else if (fieldName === 'endFishingLocation') {
+        haul.startFishingLocation.unit = haul.endFishingLocation.unit;
     }
 }
 
@@ -19,6 +30,7 @@ function getMeasurementVal(measurement: Measurement): number {
     return 0;
 }
 
+// calculate official total catch
 function setOfficialTotalCatch(haul: AshopHaul): Measurement {
     let observerEstCatch: number = 0;
     const flowScaleMeasurement = haul.flowScaleCatch ? haul.flowScaleCatch.measurement : {};

--- a/apps/ashop/src/helpers/cruiseInfo.ts
+++ b/apps/ashop/src/helpers/cruiseInfo.ts
@@ -11,6 +11,7 @@ export async function getDocByType(program: string, type: string) {
         _id: '_design/docType',
         views: {
             by_type: {
+                // @ts-ignore
                 map: function (doc) { emit(doc.type); }.toString()
             }
         }

--- a/apps/ashop/src/helpers/cruiseInfo.ts
+++ b/apps/ashop/src/helpers/cruiseInfo.ts
@@ -12,7 +12,7 @@ export async function getDocByType(program: string, type: string) {
         views: {
             by_type: {
                 // @ts-ignore
-                map: function (doc) { emit(doc.type); }.toString()
+                map: function(doc) { emit(doc.type); }.toString()
             }
         }
     };
@@ -24,9 +24,9 @@ export async function getDocByType(program: string, type: string) {
         key: program + '-' + type
     };
     let results: any = await db.query('docType/by_type', queryOptions)
-        .catch(async function (err: any) {
+        .catch(async (err: any) => {
             await db.put(designDoc);
-            return await db.query('docType/by_type', queryOptions)
+            return await db.query('docType/by_type', queryOptions);
         });
     results = results.rows;
     for (let i = 0; i < results.length; i++) {

--- a/apps/ashop/src/helpers/cruiseInfo.ts
+++ b/apps/ashop/src/helpers/cruiseInfo.ts
@@ -6,19 +6,49 @@ import { allDocs } from './queries';
 let cruise: AshopCruise;
 const db = pouchService.db;
 
-export async function getCruise(type: string, docs: any) {
-    cruise = docs.filter((row: any) => row.type === type + '-cruise');
-    cruise = cruise[0] ? cruise[0] : undefined;
-    return cruise;
+export async function getDocByType(program: string, type: string) {
+    const designDoc = {
+        _id: '_design/docType',
+        views: {
+            by_type: {
+                map: function (doc) { emit(doc.type); }.toString()
+            }
+        }
+    };
+    const queryOptions = {
+        inclusive_end: true,
+        ascending: false,
+        include_docs: true,
+        reduce: false,
+        key: program + '-' + type
+    };
+    let results: any = await db.query('docType/by_type', queryOptions)
+        .catch(async function (err: any) {
+            await db.put(designDoc);
+            return await db.query('docType/by_type', queryOptions)
+        });
+    results = results.rows;
+    for (let i = 0; i < results.length; i++) {
+        results[i] = results[i].doc;
+    }
+    return results;
 }
 
-export async function getTrips() {
-    const tripIds = cruise ? cruise.trips : [];
-    const queryOptions = {
-        keys: tripIds,
-        descending: true
-    };
-    return await allDocs(queryOptions, pouchService.userDBName);
+export async function getTrips(appMode: string) {
+    if (appMode === 'ashop') {
+        const cruises = await getDocByType(appMode, 'cruise');
+        cruise = cruises[0];
+        const tripIds = cruise ? cruise.trips : [];
+        const queryOptions = {
+            keys: tripIds,
+            descending: true
+        };
+        return await allDocs(queryOptions, pouchService.userDBName);
+    } else if (appMode === 'wcgop') {
+        const wcgopTrips = getDocByType(appMode, 'trip');
+        return wcgopTrips;
+    }
+
 }
 
 // TODO

--- a/apps/ashop/src/views/HaulDetails.vue
+++ b/apps/ashop/src/views/HaulDetails.vue
@@ -7,7 +7,7 @@
       <template v-slot:content1>
         <div style="display: flex; flex-flow: column wrap; align-items: stretch; height: 500px">
           <div v-for="config of appConfig.haulInfoPt1" :key="appConfig.haulInfoPt1.indexOf(config)">
-            <boatnet-common-input-component :config="config" :model="haul" @save="saveOnUpdate"></boatnet-common-input-component>
+            <boatnet-common-input-component :config="config" :model="haul" @save="saveOnUpdate(config.modelName)"></boatnet-common-input-component>
           </div>
         </div>
       </template>
@@ -50,10 +50,15 @@ export default createComponent({
     const appConfig = store.state.appSettings.appConfig;
     const haul: BaseOperation = reactive(store.state.tripsState.currentHaul);
     const haulName = store.state.appSettings.appConfig.hauls.itemNumName;
+    let rev: string = '';
 
-    const saveOnUpdate = async () => {
-      update(haul);
-      store.dispatch('tripsState/save', haul);
+    const saveOnUpdate = async (fieldName: string) => {
+      update(haul, fieldName);
+      const curr = haul._rev;
+      if (curr !== rev) {
+        store.dispatch('tripsState/save', haul);
+        rev = curr ? curr : '';
+      }
     };
 
     return {

--- a/apps/ashop/src/views/Trips.vue
+++ b/apps/ashop/src/views/Trips.vue
@@ -56,13 +56,7 @@ export default createComponent({
     });
 
     const init = async () => {
-      const rows = await allDocs({}, pouchService.userDBName);
-      if (appMode === 'ashop') {
-        await getCruise(appMode, rows);
-        return await getTrips();
-      } else {
-        return rows.filter((row: any) => row.type === appMode + '-trip');
-      }
+      return await getTrips(appMode)
     };
     const { data } = useAsync(init);
 

--- a/apps/ashop/src/views/Trips.vue
+++ b/apps/ashop/src/views/Trips.vue
@@ -31,7 +31,6 @@ import { pouchService, pouchState, PouchDBState } from '@boatnet/bn-pouch';
 import { useAsync } from 'vue-async-function';
 import { get, remove } from 'lodash';
 import {
-  getCruise,
   getTrips,
   updateCruise,
   deleteCruise
@@ -56,7 +55,7 @@ export default createComponent({
     });
 
     const init = async () => {
-      return await getTrips(appMode)
+      return await getTrips(appMode);
     };
     const { data } = useAsync(init);
 

--- a/libs/bn-common/src/_store/appSettings.module.ts
+++ b/libs/bn-common/src/_store/appSettings.module.ts
@@ -70,6 +70,9 @@ const getters: GetterTree<AppSettings, RootState> = {
   isSoundEnabled(getState: AppSettings) {
     return getState.isSoundEnabled;
   },
+  isKeyboardEnabled(getState: AppSettings) {
+    return getState.isKeyboardEnabled;
+  },
   appMode(getState: AppSettings) {
     return getState.appMode;
   },

--- a/libs/bn-common/src/components/BoatnetCommonInputComponent.vue
+++ b/libs/bn-common/src/components/BoatnetCommonInputComponent.vue
@@ -28,7 +28,7 @@
 
     <boatnet-location
       v-if="config.type === 'location'"
-      :model="config.model"
+      :model="config.modelName"
       :obj="model"
       @save="save"
     ></boatnet-location>

--- a/libs/bn-common/src/components/BoatnetKeyboard.vue
+++ b/libs/bn-common/src/components/BoatnetKeyboard.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="visible">
     <vue-touch-keyboard
-      v-if="layout === 'normal'"
+      v-if="layout === 'normal' && isKeyboardEnabled"
       :class="{'normalKeyboard': true,
                'keyboardWithList':(displayFields && displayFields.length != 0),
                'keyboardWithoutList': (displayFields && displayFields.length == 0)}"
@@ -13,7 +13,7 @@
       :next="next"
     />
     <vue-touch-keyboard
-      v-else-if="layout === 'numeric'"
+      v-else-if="layout === 'numeric' && isKeyboardEnabled"
       :class="{'numericKeyboard': true,
                'keyboardWithList':(displayFields && displayFields.length != 0),
                'keyboardWithoutList': (displayFields && displayFields.length == 0)}"
@@ -25,7 +25,7 @@
       :next="next"
     />
     <vue-touch-keyboard
-      v-else-if="layout === 'compact'"
+      v-else-if="layout === 'compact' && isKeyboardEnabled"
       :class="{'numericKeyboard': true,
                'keyboardWithList':(displayFields && displayFields.length != 0),
                'keyboardWithoutList': (displayFields && displayFields.length == 0)}"
@@ -36,7 +36,7 @@
       :input="inputTarget"
       :next="next"
     />
-    <div v-if="displayFields && displayFields.length != 0">
+    <div v-if="displayFields && displayFields.length != 0 && isKeyboardEnabled">
       <boatnet-keyboard-list
         class="list"
         v-on:selected="select"
@@ -51,6 +51,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Emit } from 'vue-property-decorator';
+import { Getter } from 'vuex-class';
 
 @Component
 export default class BoatnetKeyboard extends Vue {
@@ -61,6 +62,9 @@ export default class BoatnetKeyboard extends Vue {
   @Prop() public docType !: string;
   @Prop() public inputValue!: string;
   @Prop() public valType!: string;
+
+  @Getter('isKeyboardEnabled', { namespace: 'appSettings' })
+  private isKeyboardEnabled!: boolean;
 
   private keyboardOptions = {
     useKbEvents: false,
@@ -87,7 +91,7 @@ export default class BoatnetKeyboard extends Vue {
 
 <style scoped lang="scss">
 .popover {
-  position: absolute;
+  position: fixed;
   bottom: 0;
 
   z-index: 10000;

--- a/libs/bn-common/src/components/BoatnetTable.vue
+++ b/libs/bn-common/src/components/BoatnetTable.vue
@@ -53,7 +53,7 @@ export default class BoatnetTable extends Vue {
   private pagination = { rowsPerPage: 0 };
 
   private select(row: any) {
-    if (this.selected.length > 0 && this.selected[0].__index === row.__index) {
+    if (this.selected.length > 0 && this.selected[0]._id === row._id) {
       this.selected = [];
       this.$emit('select', undefined);
     } else {


### PR DESCRIPTION
- set fishing location units equal to each other
- adding views based on doc type in user database. https://github.com/nwfsc-fram/boatnet/issues/1193

fixing some minor bugs
- there were revision updates to the hauls doc so added some code in haul details to check for rev before updating. 
- When selecting a row from a table sometimes you had to click it twice in order for it to show up as selected
- previously when you selected hide keyboard from setting page this had no effect, fixed it to actually hide the keyboard. 
