### PR TITLE
getting rid of keep alive

### DIFF
--- a/apps/obs-web/src/_store/debriefer.module.ts
+++ b/apps/obs-web/src/_store/debriefer.module.ts
@@ -13,13 +13,17 @@ export const state: DebrieferState = {
   tripSearchFilters: {},
   tripIds: [],
   displayColumns: {},
+  selectedTrips: [],
   trips: [],
   selectedOperations: [],
   operations: [],
-  specimens: [],
+  biospecimens: [],
+  selectedBiospecimens: [],
   filters: {},
   errors: [],
-  newDcsRow: ''
+  newDcsRow: '',
+  expandedCatch: {},
+  catches: []
 };
 
 const actions: ActionTree<DebrieferState, RootState> = {
@@ -41,6 +45,9 @@ const actions: ActionTree<DebrieferState, RootState> = {
   updateTripSearchFilters({ commit }: any, value: any) {
     commit('updateVal', {id: 'tripSearchFilters', val: value});
   },
+  updateSelectedTrips({ commit }: any, value: any) {
+    commit('updateVal', {id: 'selectedTrips', val: value});
+  },
   updateTrips({ commit }: any, value: any) {
     commit('updateVal', {id: 'trips', val: value});
   },
@@ -50,8 +57,11 @@ const actions: ActionTree<DebrieferState, RootState> = {
   updateSelectedOperations({ commit }: any, value: any) {
     commit('updateVal', {id: 'selectedOperations', val: value});
   },
-  updateSpecimens({ commit }: any, value: any) {
-    commit('updateVal', {id: 'specimens', val: value});
+  updateBiospecimens({ commit }: any, value: any) {
+    commit('updateVal', {id: 'biospecimens', val: value});
+  },
+  updateSelectedBiospecimens({ commit }: any, value: any) {
+    commit('updateVal', {id: 'selectedBiospecimens', val: value});
   },
   updateDisplayColumns({ commit }: any, value: any) {
     commit('updateDisplayColumns', value);
@@ -61,6 +71,12 @@ const actions: ActionTree<DebrieferState, RootState> = {
   },
   setNewDcsRow({ commit }: any, value: any) {
     commit('updateVal', {id: 'newDcsRow', val: value});
+  },
+  updateExpandedCatch({ commit }: any, value: any) {
+    commit('updateVal', {id: 'expandedCatch', val: value});
+  },
+  updateCatches({ commit }: any, value: any) {
+    commit('updateVal', {id: 'catches', val: value});
   },
 };
 

--- a/apps/obs-web/src/_store/types/types.ts
+++ b/apps/obs-web/src/_store/types/types.ts
@@ -19,13 +19,17 @@ export interface DebrieferState {
   tripIds: string[];
   displayColumns: any;
   trips: any[];
+  selectedTrips: any[];
   selectedOperations: any[];
   operations: any[];
   tripSearchFilters: any;
-  specimens: any[];
+  biospecimens: any[];
+  selectedBiospecimens: any[];
   filters: any;
   errors: any[];
   newDcsRow: any;
+  expandedCatch: {};
+  catches: any[];
 }
 
 export interface TripState {

--- a/apps/obs-web/src/views/DebrieferBiospecimens.vue
+++ b/apps/obs-web/src/views/DebrieferBiospecimens.vue
@@ -2,13 +2,8 @@
   <div>
     <prime-table
       :value="WcgopBiospecimens"
-<<<<<<< Updated upstream
-      :columns="displayColumns && displayColumns['wcgop-Specimens'] ? displayColumns['wcgop-Specimens'] : columns"
-      type="Specimens"
-=======
       :columns="columns"
       type="biospecimens"
->>>>>>> Stashed changes
       uniqueKey="_id"
       :initialSelection="initialSelection"
       :enableSelection="true"

--- a/apps/obs-web/src/views/DebrieferBiospecimens.vue
+++ b/apps/obs-web/src/views/DebrieferBiospecimens.vue
@@ -2,8 +2,13 @@
   <div>
     <prime-table
       :value="WcgopBiospecimens"
+<<<<<<< Updated upstream
       :columns="displayColumns && displayColumns['wcgop-Specimens'] ? displayColumns['wcgop-Specimens'] : columns"
       type="Specimens"
+=======
+      :columns="columns"
+      type="biospecimens"
+>>>>>>> Stashed changes
       uniqueKey="_id"
       :initialSelection="initialSelection"
       :enableSelection="true"
@@ -38,23 +43,37 @@ export default createComponent({
     const displayColumns: any = state.debriefer.displayColumns;
 
     onUnmounted(() => {
-      store.dispatch('debriefer/updateSpecimens', []);
+      store.dispatch('debriefer/updateSelectedBiospecimens', []);
     });
 
     const columns = [
+      {
+        field: 'tripId',
+        header: 'Trip #',
+        type: 'number',
+        key: 'wcgopBioTripId',
+        width: '80'
+      },
+      {
+        field: 'operationNum',
+        header: 'Haul #',
+        type: 'number',
+        key: 'wcgopBioHaulNum',
+        width: '80'
+      },
+      {
+        field: 'catchNum',
+        header: 'Catch #',
+        type: 'number',
+        key: 'wcgopBioCatchNum',
+        width: '80'
+      },
       {
         field: 'species',
         header: 'Species',
         type: 'input',
         key: 'wcgopBioSpecies',
         width: '150'
-      },
-      {
-        field: 'tripId',
-        header: 'Trip Id',
-        type: 'number',
-        key: 'wcgopBioTripId',
-        width: '80'
       },
       {
         field: 'received',
@@ -64,13 +83,6 @@ export default createComponent({
         listType: 'template',
         key: 'wcgopBioReceived',
         isEditable: true,
-        width: '80'
-      },
-      {
-        field: 'operationNum',
-        header: 'Haul #',
-        type: 'number',
-        key: 'wcgopBioHaulNum',
         width: '80'
       },
       {
@@ -211,59 +223,65 @@ export default createComponent({
     watch(() => state.debriefer.selectedOperations, getBiospecimens);
 
     async function getBiospecimens() {
-      const operations = state.debriefer.selectedOperations;
-      const unflattenedOperations: any[] = [];
-      for (const op of operations) {
-        unflattenedOperations.push(unflatten(op, { delimiter: '-' }));
-      }
+      let bioSpecimens: any[] = [];
+      if (state.debriefer.biospecimens.length > 1) {
+        bioSpecimens = state.debriefer.biospecimens;
+      } else {
+        const operations = state.debriefer.selectedOperations;
+        const unflattenedOperations: any[] = [];
+        for (const op of operations) {
+          unflattenedOperations.push(unflatten(op, { delimiter: '-' }));
+        }
 
-      const bioSpecimens: any[] = [];
-      const id: number = 1;
-      const specimens = jp.nodes(unflattenedOperations, '$..specimens');
+        const id: number = 1;
+        const specimens = jp.nodes(unflattenedOperations, '$..specimens');
 
-      for (const specimen of specimens) {
-        const operationPath = jp.stringify(slice(specimen.path, 0, 2));
-        const catchesPath = jp.stringify(slice(specimen.path, 0, 4));
-        const childrenPath = jp.stringify(slice(specimen.path, 0, 6));
+        for (const specimen of specimens) {
+          const operationPath = jp.stringify(slice(specimen.path, 0, 2));
+          const catchesPath = jp.stringify(slice(specimen.path, 0, 4));
+          const childrenPath = jp.stringify(slice(specimen.path, 0, 6));
 
-        const tripId = jp.value(unflattenedOperations, operationPath + '.legacy.tripId');
-        const operationNum = jp.value(
-          unflattenedOperations,
-          operationPath + '.operationNum'
-        );
-        const operationId = jp.value(unflattenedOperations, operationPath + '._id');
-        const operationRev = jp.value(unflattenedOperations, operationPath + '._rev');
-        let disposition = jp.value(
-          unflattenedOperations,
-          catchesPath + '.disposition.description'
-        );
-        disposition = disposition === 'Retained' ? 'R' : 'D';
-        const species = jp.value(
-          unflattenedOperations,
-          childrenPath + '.catchContent.commonNames[0]'
-        );
+          const tripId = jp.value(unflattenedOperations, operationPath + '.legacy.tripId');
+          const operationNum = jp.value(
+            unflattenedOperations,
+            operationPath + '.operationNum'
+          );
+          const operationId = jp.value(unflattenedOperations, operationPath + '._id');
+          const operationRev = jp.value(unflattenedOperations, operationPath + '._rev');
+          const catchNum = jp.value(unflattenedOperations, catchesPath + '.catchNum');
+          let disposition = jp.value(
+            unflattenedOperations,
+            catchesPath + '.disposition.description'
+          );
+          disposition = disposition === 'Retained' ? 'R' : 'D';
+          const species = jp.value(
+            unflattenedOperations,
+            childrenPath + '.catchContent.commonNames[0]'
+          );
 
-        for (const indivSpecimen of specimen.value) {
-          if (indivSpecimen._id) {
-            const biospecimen = {
-              _id: indivSpecimen._id,
-              tripId,
-              operationNum,
-              operationId,
-              operationRev,
-              disposition,
-              species,
-              specimen: indivSpecimen
-            };
-            bioSpecimens.push(biospecimen);
-          } else {
-            console.log('id not found skipping record');
+          for (const indivSpecimen of specimen.value) {
+            if (indivSpecimen._id) {
+              const biospecimen = {
+                _id: indivSpecimen._id,
+                tripId,
+                operationNum,
+                catchNum,
+                operationId,
+                operationRev,
+                disposition,
+                species,
+                specimen: indivSpecimen
+              };
+              bioSpecimens.push(biospecimen);
+            } else {
+              console.log('id not found skipping record');
+            }
           }
         }
       }
-      WcgopBiospecimens.value = orderBy(bioSpecimens, ['operationNum']);
+      WcgopBiospecimens.value = orderBy(bioSpecimens, ['tripId', 'operationNum', 'catchNum'], ['asc', 'asc', 'asc']);
       initialSelection.value = filter(WcgopBiospecimens.value, (val: any) => {
-        if (debriefer.specimens.includes(val._id)) {
+        if (debriefer.selectedBiospecimens.includes(val._id)) {
           return val;
         }
       });
@@ -286,6 +304,7 @@ export default createComponent({
         return value;
       });
       WcgopBiospecimens.value = updatedvalue;
+      store.dispatch('debriefer/updateSpecimens', WcgopBiospecimens.value);
     }
 
     return {

--- a/apps/obs-web/src/views/DebrieferBiospecimens.vue
+++ b/apps/obs-web/src/views/DebrieferBiospecimens.vue
@@ -299,7 +299,7 @@ export default createComponent({
         return value;
       });
       WcgopBiospecimens.value = updatedvalue;
-      store.dispatch('debriefer/updateSpecimens', WcgopBiospecimens.value);
+      store.dispatch('debriefer/updateBiospecimens', WcgopBiospecimens.value);
     }
 
     return {

--- a/apps/obs-web/src/views/DebrieferCatches.vue
+++ b/apps/obs-web/src/views/DebrieferCatches.vue
@@ -7,8 +7,12 @@
       :isEditable="true"
       :program="program"
       type="catch"
+      :isFullSize="isFullSize"
       @save="save"
       @selected="select"
+      :initExpandedKeys="expandedKeys"
+      @expand="addNode"
+      @collapse="removeNode"
     ></boatnet-tree-table>
   </div>
 </template>
@@ -18,7 +22,7 @@ import { createComponent, ref, watch } from '@vue/composition-api';
 import { couchService } from '@boatnet/bn-couch';
 import { Client } from 'davenport';
 import { updateCatchWeight } from '@boatnet/bn-expansions';
-import { merge, get } from 'lodash';
+import { merge, get, orderBy } from 'lodash';
 
 export default createComponent({
   props: {
@@ -35,6 +39,7 @@ export default createComponent({
     const flatten = require('flat');
     const unflatten = flatten.unflatten;
     const jp = require('jsonpath');
+    const expandedKeys: any = state.debriefer.expandedCatch ? state.debriefer.expandedCatch : {};
 
     const wcgopColumns = [
         {
@@ -159,150 +164,171 @@ export default createComponent({
         }
     ];
 
-    watch(() => state.debriefer.trips, getCatches);
+    watch(() => state.debriefer.selectedTrips, getCatches);
     watch(() => state.debriefer.selectedOperations, getCatches);
 
     function select(item: string[]) {
-      store.dispatch('debriefer/updateSpecimens', item);
+      store.dispatch('debriefer/updateSelectedBiospecimens', item);
       context.emit('changeTab', 'biospecimens');
     }
 
+    function addNode(currExpandedKeys: any) {
+      store.dispatch('debriefer/updateExpandedCatch', currExpandedKeys);
+    }
+    function removeNode(currExpandedKeys: any) {
+      store.dispatch('debriefer/updateExpandedCatch', currExpandedKeys);
+    }
+
     async function getCatches() {
-      const catches: any[] = [];
+      let catches: any[] = [];
       let color = '#344B5F';
-      for (const operation of state.debriefer.selectedOperations) {
-        const unflattenedOperation = unflatten(operation, { delimiter: '-' });
-        let catchIndex = 0;
-        color = color === '#FFFFFF' ? '#344B5F' : '#FFFFFF';
-        for (const c of unflattenedOperation.catches) {
-          const tripId = unflattenedOperation.legacy.tripId;
-          const operationNum = unflattenedOperation.operationNum;
-          const operationId = unflattenedOperation._id;
-          let disposition = c.disposition ? c.disposition.description : '';
-          const wm = c.weightMethod ? c.weightMethod.description : '';
-          let weight: any = c.weight ? c.weight.value : null;
-          const sampleWeight: any = c.sampleWeight
-            ? c.sampleWeight.value
-            : null;
-          weight = weight ? weight : sampleWeight;
-          const count = c.count;
-          const catchContent = c.catchContent;
-          const name = catchContent ? catchContent.name : '';
-          const children: any[] = [];
-          let childIndex = 0;
-          const key = operationId + '_' + catchIndex;
+      if (state.debriefer.catches.length > 1) {
+       catches = state.debriefer.catches;
+      } else {
+        for (const operation of state.debriefer.selectedOperations) {
+          const unflattenedOperation = unflatten(operation, { delimiter: '-' });
+          let catchIndex = 0;
+          color = color === '#FFFFFF' ? '#344B5F' : '#FFFFFF';
+          for (const c of unflattenedOperation.catches) {
+            const tripId = unflattenedOperation.legacy.tripId;
+            const operationNum = unflattenedOperation.operationNum;
+            const operationId = unflattenedOperation._id;
+            let disposition = c.disposition ? c.disposition.description : '';
+            const wm = c.weightMethod ? c.weightMethod.description : '';
+            let weight: any = c.weight ? c.weight.value : null;
+            const sampleWeight: any = c.sampleWeight
+              ? c.sampleWeight.value
+              : null;
+            weight = weight ? weight : sampleWeight;
+            const count = c.count;
+            const catchContent = c.catchContent;
+            const name = catchContent ? catchContent.name : '';
+            const children: any[] = [];
+            let childIndex = 0;
+            const key = operationId + '_' + catchIndex;
 
-          if (disposition === 'Retained') {
-            disposition = 'R';
-          } else if (disposition === 'Discarded') {
-            disposition = 'D';
-          }
+            if (disposition === 'Retained') {
+              disposition = 'R';
+            } else if (disposition === 'Discarded') {
+              disposition = 'D';
+            }
 
-          if (c.children) {
-            for (const child of c.children) {
-              const discardReason =  jp.query(child, '$..discardReason.description')[0];
+            if (c.children) {
+              for (const child of c.children) {
+                const discardReason =  jp.query(child, '$..discardReason.description')[0];
 
-              const catchContents = child.catchContent;
-              const catchName = catchContents
-                ? catchContents.commonNames[0]
-                : '';
-              const childWeight = jp.query(child, 'weight.value')[0];
-              const childCount = child.sampleCount;
-              let toolTipInfo: string = '';
+                const catchContents = child.catchContent;
+                const catchName = catchContents
+                  ? catchContents.commonNames[0]
+                  : '';
+                const childWeight = jp.query(child, 'weight.value')[0];
+                const childCount = child.sampleCount;
+                let toolTipInfo: string = '';
 
-              const specimenIds: string[] = jp.query(child, '$..specimens[*]._id');
-              const specimensCnt: number = child.specimens ? child.specimens.length : 0;
+                const specimenIds: string[] = jp.query(child, '$..specimens[*]._id');
+                const specimensCnt: number = child.specimens ? child.specimens.length : 0;
 
-              const lengths: number[] = jp.query(child, '$..specimens[*].length.value');
-              toolTipInfo += lengths.length > 0 ? 'lengths: ' + lengths.join(', ') : '';
+                const lengths: number[] = jp.query(child, '$..specimens[*].length.value');
+                toolTipInfo += lengths.length > 0 ? 'lengths: ' + lengths.join(', ') : '';
 
-              const specimenType: string[] = jp.query(child, '$..specimens[*].biostructures[*].structureType.description');
-              toolTipInfo += specimenType.length > 0 ? ' specimen types: ' + specimenType.join(', ') : '';
+                const specimenType: string[] = jp.query(child, '$..specimens[*].biostructures[*].structureType.description');
+                toolTipInfo += specimenType.length > 0 ? ' specimen types: ' + specimenType.join(', ') : '';
 
-              const sex: string[] = jp.query(child, '$..specimens[*].sex');
-              toolTipInfo += sex.length > 0 ? ' sex: ' + sex.join(', ') : '';
+                const sex: string[] = jp.query(child, '$..specimens[*].sex');
+                toolTipInfo += sex.length > 0 ? ' sex: ' + sex.join(', ') : '';
 
-              const viability: string[] = jp.query(child, '$..specimens[*].viability.description');
-              toolTipInfo += viability.length > 0 ? ' viability: ' + viability.join(', ') : '';
+                const viability: string[] = jp.query(child, '$..specimens[*].viability.description');
+                toolTipInfo += viability.length > 0 ? ' viability: ' + viability.join(', ') : '';
 
-              const baskets: any[] = [];
-              let basketCnt;
-              if (child.baskets) {
-                basketCnt = child.baskets.length;
-                let basketCount = 1;
-                for (const basket of child.baskets) {
-                  baskets.push({
-                    key: key + '_' + childIndex + '_' + basketCount,
-                    data: {
-                      name: 'Basket ' + basketCount,
-                      weight: basket.weight.value,
-                      count: basket.count,
-                      avgWt: basket.weight.value / basket.count,
-                      disposition,
-                      weightMethod: wm,
-                      operationNum,
-                      catchNum: c.catchNum,
-                      type: 'basket'
-                    }
-                  });
-                  basketCount++;
+                const baskets: any[] = [];
+                let basketCnt;
+                if (child.baskets) {
+                  basketCnt = child.baskets.length;
+                  let basketCount = 1;
+                  for (const basket of child.baskets) {
+                    baskets.push({
+                      key: key + '_' + childIndex + '_' + basketCount,
+                      data: {
+                        name: 'Basket ' + basketCount,
+                        weight: basket.weight.value,
+                        count: basket.count,
+                        avgWt: basket.weight.value / basket.count,
+                        disposition,
+                        weightMethod: wm,
+                        operationNum,
+                        catchNum: c.catchNum,
+                        type: 'basket'
+                      }
+                    });
+                    basketCount++;
+                  }
                 }
+                const newChild: any = {
+                  key: key + '_' + childIndex,
+                  data: {
+                    specimensCnt,
+                    specimenIds,
+                    basketCnt,
+                    toolTipInfo,
+                    discardReason,
+                    name: catchName,
+                    catchContent: catchContents,
+                    weight: childWeight,
+                    count: childCount,
+                    disposition,
+                    weightMethod: wm,
+                    operationNum,
+                    catchNum: c.catchNum,
+                    type: 'child'
+                  }
+                };
+                // if there is only one basket do not show dropdown row
+                // instead, merge info with top level item
+                if (baskets.length === 1) {
+                  const combined = merge(newChild, baskets[0]);
+                  combined.data.type = 'child';
+                  combined.data.name = catchName;
+                  children.push(combined);
+                } else {
+                  newChild.children = baskets;
+                  children.push(newChild);
+                }
+                childIndex++;
               }
-
-              children.push({
-                key: key + '_' + childIndex,
-                data: {
-                  specimensCnt,
-                  specimenIds,
-                  basketCnt,
-                  toolTipInfo,
-                  discardReason,
-                  name: catchName,
-                  catchContent: catchContents,
-                  weight: childWeight,
-                  count: childCount,
-                  disposition,
-                  weightMethod: wm,
-                  operationNum,
-                  catchNum: c.catchNum,
-                  type: 'child'
-                },
-                children: baskets
-              });
-              childIndex++;
             }
-          }
 
-          const newCatchItem: any = {
-            key,
-            style: color === '#FFFFFF' ? 'background: #FFFFFF' : 'background: #E9ECEF', // f4f4f4
-            data: {
-              tripId,
-              operationNum,
-              operationId,
-              catchNum: c.catchNum,
-              disposition,
-              weightMethod: wm,
-              name,
-              catchContent,
-              weight,
-              count,
-              type: 'topLevel'
+            const newCatchItem: any = {
+              key,
+              style: color === '#FFFFFF' ? 'background: #FFFFFF' : 'background: #E9ECEF', // f4f4f4
+              data: {
+                tripId,
+                operationNum,
+                operationId,
+                catchNum: c.catchNum,
+                disposition,
+                weightMethod: wm,
+                name,
+                catchContent,
+                weight,
+                count,
+                type: 'topLevel'
+              }
+            };
+            // if there is only one basket do not show dropdown row
+            // instead, merge info with top level item
+            if (children.length === 1) {
+              const combined = merge(newCatchItem, children[0]);
+              combined.data.type = 'topLevel';
+              catches.push(combined);
+            } else {
+              newCatchItem.children = children;
+              catches.push(newCatchItem);
             }
-          };
-          // if there is only one basket do not show dropdown row
-          // instead, merge info with top level item
-          if (children.length === 1) {
-            const combined = merge(newCatchItem, children[0]);
-            combined.data.type = 'topLevel';
-            catches.push(combined);
-          } else {
-            newCatchItem.children = children;
-            catches.push(newCatchItem);
+            catchIndex++;
           }
-          catchIndex++;
         }
       }
+      catches = orderBy(catches, ['data.tripId', 'data.operationNum', 'data.catchNum'], ['asc', 'asc', 'asc']);
       WcgopCatches.value = catches;
     }
     getCatches();
@@ -374,6 +400,7 @@ export default createComponent({
           }
         }
         operationRecord.catches = catches;
+        store.dispatch('debriefer/updateCatches', catches);
         await masterDB.put(
           operationRecord._id,
           operationRecord,
@@ -425,10 +452,13 @@ export default createComponent({
     }
 
     return {
+      addNode,
+      removeNode,
       WcgopCatches,
       wcgopColumns,
       program,
       lookupsList,
+      expandedKeys,
       save,
       select
     };

--- a/apps/obs-web/src/views/DebrieferErrors.vue
+++ b/apps/obs-web/src/views/DebrieferErrors.vue
@@ -87,7 +87,7 @@ export default createComponent({
       loading.value = true;
       errorDocs.value.length = 0;
       errorRows.value = [];
-      for (const trip of state.debriefer.trips) {
+      for (const trip of state.debriefer.selectedTrips) {
         getErrors(trip['legacy-tripId']);
       }
       loading.value = false;
@@ -130,7 +130,7 @@ export default createComponent({
 
     onMounted( () => getErrorStatuses() );
 
-    watch(() => state.debriefer.trips, getTripErrors);
+    watch(() => state.debriefer.selectedTrips, getTripErrors);
 
     return {
       errorRows, errorColumns, loading, save

--- a/apps/obs-web/src/views/DebrieferOperations.vue
+++ b/apps/obs-web/src/views/DebrieferOperations.vue
@@ -44,6 +44,8 @@ export default createComponent({
 
         watch(() => state.debriefer.operations, getOperations);
 
+        getOperations();
+
         const wcgopColumns = [
             {
                 field: 'legacy-tripId',
@@ -58,6 +60,14 @@ export default createComponent({
                 type: 'number',
                 key: 'wcgopOpHaulNum',
                 width: '60',
+            },
+            {
+                field: 'targetStrategy',
+                header: 'Target Strategy',
+                type: 'input',
+                key: 'wcgopOptargetStrategy',
+                width: '100',
+                isEditable: true
             },
             {
                 field: 'haulScore',
@@ -99,55 +109,6 @@ export default createComponent({
                 search: true,
                 lookupKey: 'gear-performance',
                 lookupField: 'description',
-                isEditable: true,
-            },
-            {
-                field: 'totalHooks',
-                header: 'Total Hooks',
-                type: 'number',
-                key: 'wcgopOpTotHooks',
-                width: '100',
-                isEditable: true,
-            },
-            {
-                field: 'totalGearSegments',
-                header: 'Total Gear Segments',
-                type: 'number',
-                key: 'wcgopOpTotGear',
-                width: '100',
-                isEditable: true,
-            },
-            {
-                field: 'avgNumHooksPerSegment',
-                header: 'Hook Count Per Segment',
-                type: 'number',
-                key: 'wcgopOpAvgNumHooksPerSeg',
-                width: '100',
-                isEditable: true,
-            },
-            {
-                field: 'catches-0-legacy-hooksSampled',
-                header: 'Hooks Sampled',
-                type: 'number',
-                key: 'wcgopOpHooksSampled',
-                width: '100',
-                isEditable: true,
-            },
-            {
-                field: 'gearSegmentsLost',
-                header: 'Lost Gear',
-                type: 'number',
-                key: 'wcgopOpTotGearLost',
-                width: '100',
-                isEditable: true,
-            },
-            // sea bird avoidance
-            {
-                field: 'avgSoakTime-value',
-                header: 'Average Soak Time',
-                type: 'number',
-                key: 'wcgopOpAvgSoakTime',
-                width: '100',
                 isEditable: true,
             },
             {
@@ -246,24 +207,7 @@ export default createComponent({
                 width: '250',
                 isEditable: true,
             },
-            {
-                field: 'legacy-isBrdPresent',
-                header: 'BRD',
-                type: 'toggle',
-                listType: 'boolean',
-                key: 'wcgopOpIsBRDPresent',
-                width: '100',
-                isEditable: true
-            },
             // HLFC
-            {
-                field: 'targetStrategy',
-                header: 'Target Strategy',
-                type: 'input',
-                key: 'wcgopOptargetStrategy',
-                width: '100',
-                isEditable: true
-            },
             {
                 field: 'isEfpUsed',
                 header: 'EFP',
@@ -282,6 +226,64 @@ export default createComponent({
                 width: '200',
                 isEditable: true,
             },
+            {
+                field: 'legacy-isBrdPresent',
+                header: 'BRD',
+                type: 'toggle',
+                listType: 'boolean',
+                key: 'wcgopOpIsBRDPresent',
+                width: '100',
+                isEditable: true
+            },
+            {
+                field: 'totalHooks',
+                header: 'Total Hooks',
+                type: 'number',
+                key: 'wcgopOpTotHooks',
+                width: '100',
+                isEditable: true,
+            },
+            {
+                field: 'totalGearSegments',
+                header: 'Total Gear Segments',
+                type: 'number',
+                key: 'wcgopOpTotGear',
+                width: '100',
+                isEditable: true,
+            },
+            {
+                field: 'avgNumHooksPerSegment',
+                header: 'Hook Count Per Segment',
+                type: 'number',
+                key: 'wcgopOpAvgNumHooksPerSeg',
+                width: '100',
+                isEditable: true,
+            },
+            {
+                field: 'catches-0-legacy-hooksSampled',
+                header: 'Hooks Sampled',
+                type: 'number',
+                key: 'wcgopOpHooksSampled',
+                width: '100',
+                isEditable: true,
+            },
+            {
+                field: 'gearSegmentsLost',
+                header: 'Lost Gear',
+                type: 'number',
+                key: 'wcgopOpTotGearLost',
+                width: '100',
+                isEditable: true,
+            },
+            // sea bird avoidance
+            {
+                field: 'avgSoakTime-value',
+                header: 'Average Soak Time',
+                type: 'number',
+                key: 'wcgopOpAvgSoakTime',
+                width: '100',
+                isEditable: true,
+            }
         ];
 
         function selectValues(data: any) {
@@ -295,6 +297,7 @@ export default createComponent({
             updatedvalue[index] = data;
             updatedvalue[index]._rev = result.rev;
             operations.value = updatedvalue;
+            store.dispatch('debriefer/updateOperations', operations.value);
         }
         async function getOperations() {
             loading.value = true;

--- a/apps/obs-web/src/views/DebrieferOperations.vue
+++ b/apps/obs-web/src/views/DebrieferOperations.vue
@@ -2,7 +2,7 @@
     <div>
         <prime-table
             :value="operations"
-            :columns="displayColumns && displayColumns['wcgop-Operations'] ? displayColumns['wcgop-Operations'] : wcgopColumns"
+            :columns="wcgopColumns"
             type="Operations"
             uniqueKey="_id"
             :enableSelection="true"

--- a/apps/obs-web/src/views/DebrieferTrips.vue
+++ b/apps/obs-web/src/views/DebrieferTrips.vue
@@ -2,7 +2,7 @@
   <div>
     <prime-table
       :value="trips"
-      :columns="displayColumns && displayColumns['wcgop-Trips'] ? displayColumns['wcgop-Trips'] : columns"
+      :columns="columns"
       type="Trips"
       :simple="false"
       uniqueKey="_id"

--- a/apps/obs-web/src/views/DebrieferWcgopData.vue
+++ b/apps/obs-web/src/views/DebrieferWcgopData.vue
@@ -35,7 +35,7 @@
 
         <q-separator />
 
-        <q-tab-panels v-model="tab" animated :keep-alive="true">
+        <q-tab-panels v-model="tab" animated>
           <q-tab-panel name="trips">
             <app-debriefer-trips :isFullSize="isFullSize"></app-debriefer-trips>
           </q-tab-panel>
@@ -71,7 +71,6 @@ import { Client, CouchDoc, ListOptions } from 'davenport';
 
 export default createComponent({
   props: {
-    showErrors: Boolean,
     startingTab: String,
     isFullSize: Boolean
   },
@@ -84,7 +83,7 @@ export default createComponent({
     const masterDB: Client<any> = couchService.masterDB;
     const jp = require('jsonpath');
 
-    watch(() => state.debriefer.trips, update);
+    watch(() => state.debriefer.selectedTrips, update);
     watch(() => state.debriefer.selectedOperations, update);
     watch(() => state.debriefer.evaluationPeriod, setToTripTab);
     watch(() => state.debriefer.observer, setToTripTab);
@@ -110,7 +109,7 @@ export default createComponent({
     function update() {
       filters.value = [];
       const trips = updateFilter(
-        state.debriefer.trips,
+        state.debriefer.selectedTrips,
         'Trip',
         'legacy-tripId'
       );
@@ -140,7 +139,7 @@ export default createComponent({
 
     function remove(item: any) {
       let index = -1;
-      const trips = state.debriefer.trips;
+      const trips = state.debriefer.selectedTrips;
       const ops = state.debriefer.selectedOperations;
 
       if (item.type === 'wcgop-trip') {
@@ -149,7 +148,7 @@ export default createComponent({
         if (trips.length === 0) {
           updateTab('trips');
         }
-        store.dispatch('debriefer/updateTrips', trips);
+        store.dispatch('debriefer/updateSelectedTrips', trips);
         removeOperations();
       } else {
         index = findIndex(ops, item);
@@ -163,7 +162,7 @@ export default createComponent({
 
     function removeOperations() {
       const tripIds: number[] = [];
-      for (const trip of state.debriefer.trips) {
+      for (const trip of state.debriefer.selectedTrips) {
         tripIds.push(get(trip, 'legacy-tripId'));
       }
       // remove operations

--- a/apps/obs-web/src/views/DebrieferWcgopEvaluation.vue
+++ b/apps/obs-web/src/views/DebrieferWcgopEvaluation.vue
@@ -163,11 +163,13 @@ export default createComponent({
 
     function clearFilters() {
       store.dispatch('debriefer/setTripIds', []);
-      store.dispatch('debriefer/updateTrips', []);
+      store.dispatch('debriefer/updateSelectedTrips', []);
       store.dispatch('debriefer/updateOperations', []);
       store.dispatch('debriefer/updateSelectedOperations', []);
       store.dispatch('debriefer/updateFilters', {});
-      state.debriefer.trips.splice(0, state.debriefer.trips.length);
+      store.dispatch('debriefer/updateSpecimens', []);
+      store.dispatch('debriefer/updateCatches', []);
+      state.debriefer.selectedTrips.splice(0, state.debriefer.selectedTrips.length);
       state.debriefer.operations.splice(0, state.debriefer.operations.length);
     }
     clearFilters();

--- a/apps/obs-web/src/views/PrimeTable.vue
+++ b/apps/obs-web/src/views/PrimeTable.vue
@@ -9,7 +9,7 @@
       :selectionMode="enableSelection ? null : 'multiple'"
       :first="pageStart"
       :selection.sync="selected"
-      :scrollHeight="isFullSize ? '70vh' : '55vh'"
+      :scrollHeight="isFullSize ? '70vh' : '50vh'"
       :scrollable="true"
       editMode="cell"
       columnResizeMode="expand"
@@ -286,6 +286,11 @@ export default createComponent({
       updateStatePermissions = true;
       const initFilters = state.debriefer.filters[tableType];
       filters.value = initFilters ? initFilters : {};
+      if (tableType === 'wcgop-Operations' && displayMode === trawlMode) {
+        displayColumns.value = setTrawlMode(stateDisplayCols[tableType]);
+        } else if (tableType === 'wcgop-Operations' && displayMode === fixedGearMode) {
+          displayColumns.value = setFixedGearMode(stateDisplayCols[tableType]);
+        }
     });
 
     onUnmounted(async () => {
@@ -346,11 +351,6 @@ export default createComponent({
         } else {
           currCols.value = stateDisplayCols[tableType];
         }
-        if (tableType === 'wcgop-Operation' && displayMode === trawlMode) {
-          currCols.value = setTrawlMode(currCols.value);
-        } else if (tableType === 'wcgop-Operation' && displayMode === fixedGearMode) {
-          currCols.value = setFixedGearMode(currCols.value);
-        }
         return currCols.value;
       },
       set: (val) => {
@@ -361,13 +361,13 @@ export default createComponent({
     });
 
     function reorderColumn(event: any) {
-      testCols.value = arrayMove(testCols.value, event.dragIndex - 1, event.dropIndex - 1);
+      displayColumns.value = arrayMove(displayColumns.value, event.dragIndex - 1, event.dropIndex - 1);
     }
 
     function resizeColumn(event: any) {
       const colIndex = event.element.cellIndex - 1;
-      const width = parseFloat(testCols.value[colIndex].width);
-      testCols.value[colIndex].width = (width + event.delta).toString();
+      const width = parseFloat(displayColumns.value[colIndex].width);
+      displayColumns.value[colIndex].width = (width + event.delta).toString();
     }
 
     /**
@@ -386,14 +386,14 @@ export default createComponent({
     }
 
     async function saveColumnConfiguration() {
-      stateDisplayCols[tableType] = testCols.value;
+      stateDisplayCols[tableType] = displayColumns.value;
       store.dispatch('debriefer/updateDisplayColumns', stateDisplayCols);
 
       // save columns to users column-config docs
       let userColConfig: any = await masterDB.viewWithDocs('obs_web', 'column-config', { key: state.user.activeUserAlias.personDocId });
       if (userColConfig.rows.length > 0) {
         userColConfig = userColConfig.rows[0].doc;
-        userColConfig.columnConfig[tableType] = testCols.value;
+        userColConfig.columnConfig[tableType] = displayColumns.value;
         await masterDB.put(userColConfig._id, userColConfig, userColConfig._rev);
       } else {
         const newRecord: any = {
@@ -401,7 +401,7 @@ export default createComponent({
           type: 'column-config',
           personDocId: state.user.activeUserAlias.personDocId
         };
-        newRecord.columnConfig[tableType] = testCols.value;
+        newRecord.columnConfig[tableType] = displayColumns.value;
         await masterDB.post(newRecord);
       }
     }
@@ -568,27 +568,27 @@ export default createComponent({
       const type = props.type ? props.type.toLowerCase() : '';
       const route = '/observer-web/table/' + type;
       window.open(route, '_blank');
-      context.emit('update:showErrors', false);
     }
 
     function toggleHaulCols(mode: string) {
       if (mode === trawlMode) {
         displayColumns.value = setTrawlMode(currCols.value);
-        stateDisplayCols.operationMode = trawlMode;
       } else if (mode === fixedGearMode) {
         displayColumns.value = setFixedGearMode(currCols.value);
-        stateDisplayCols.operationMode = fixedGearMode;
       }
+      stateDisplayCols.operationMode = mode;
       stateDisplayCols[tableType] = displayColumns.value;
       store.dispatch('debriefer/updateDisplayColumns', stateDisplayCols);
     }
 
     function setTrawlMode(cols: any) {
       cols = remove(cols, (n: any) => {
-          if (!['totalGearSegments', 'gearSegmentsLost', 'avgSoakTime-value', 'totalHooks', 'avgNumHooksPerSegment', 'hooksSampled'].includes(n.field)) {
+          if (!['totalGearSegments', 'gearSegmentsLost', 'avgSoakTime-value',
+                'totalHooks', 'avgNumHooksPerSegment', 'catches-0-legacy-hooksSampled',
+                'legacy-isBrdPresent'].includes(n.field)) {
             return n;
           }
-        });
+      });
       cols.push({
         field: 'legacy-isBrdPresent',
         header: 'BRD',
@@ -596,13 +596,16 @@ export default createComponent({
         listType: 'boolean',
         key: 'wcgopOpIsBRDPresent',
         width: '100',
+        isEditable: true
       });
       return cols;
     }
 
     function setFixedGearMode(cols: any) {
       cols = remove(cols, (n: any) => {
-          if (!['legacy-isBrdPresent'].includes(n.field)) {
+          if (!['totalGearSegments', 'gearSegmentsLost', 'avgSoakTime-value',
+                'totalHooks', 'avgNumHooksPerSegment', 'catches-0-legacy-hooksSampled',
+                'legacy-isBrdPresent'].includes(n.field)) {
             return n;
           }
       });
@@ -644,6 +647,14 @@ export default createComponent({
         header: 'Hook Count Per Segment',
         type: 'number',
         key: 'wcgopOpAvgNumHooksPerSeg',
+        width: '100',
+        isEditable: true,
+      });
+      cols.push({
+        field: 'catches-0-legacy-hooksSampled',
+        header: 'Hooks Sampled',
+        type: 'number',
+        key: 'wcgopOpHooksSampled',
         width: '100',
         isEditable: true,
       });

--- a/apps/obs-web/src/views/PrimeTable.vue
+++ b/apps/obs-web/src/views/PrimeTable.vue
@@ -288,9 +288,9 @@ export default createComponent({
       filters.value = initFilters ? initFilters : {};
       if (tableType === 'wcgop-Operations' && displayMode === trawlMode) {
         displayColumns.value = setTrawlMode(stateDisplayCols[tableType]);
-        } else if (tableType === 'wcgop-Operations' && displayMode === fixedGearMode) {
-          displayColumns.value = setFixedGearMode(stateDisplayCols[tableType]);
-        }
+      } else if (tableType === 'wcgop-Operations' && displayMode === fixedGearMode) {
+        displayColumns.value = setFixedGearMode(stateDisplayCols[tableType]);
+      }
     });
 
     onUnmounted(async () => {


### PR DESCRIPTION
For a while set keep-alive = true on tabs to preserve data loaded on trips, hauls, catch page rather than storing it in state. But this caused some issues with having the columns load funny so getting rid of keep alive and storing everything back in state again. 

Also fixing a few issues Phillip identified
- combining baskets into catch record if there is only one basket
- fixing trawl/fixed gear was not initializing correctly
- biospecimens highlighting again
- popout now working
- catch info is sorted
- basket label not showing in filter