### PR TITLE
Small fixes

### DIFF
--- a/apps/obs-web/src/views/DebrieferAshopData.vue
+++ b/apps/obs-web/src/views/DebrieferAshopData.vue
@@ -1,8 +1,5 @@
 <template>
   <div>
-    <div style="text-align: right">
-      <q-icon name="open_in_new" size="md" v-on:click="openNewDebriefingTab" />
-    </div>
     <div class="q-gutter-y-md">
       <q-card v-if="showData">
         <q-tabs

--- a/apps/obs-web/src/views/DebrieferCatches.vue
+++ b/apps/obs-web/src/views/DebrieferCatches.vue
@@ -52,7 +52,8 @@ export default createComponent({
           field: 'tripId',
           width: '150',
           expander: true,
-          isEditable: false
+          isEditable: false,
+          order: 1
         },
         {
           name: 'operationNum',
@@ -61,7 +62,8 @@ export default createComponent({
           align: 'left',
           field: 'operationNum',
           width: '80',
-          isEditable: false
+          isEditable: false,
+          order: 2
         },
         {
           name: 'catchNum',
@@ -70,7 +72,8 @@ export default createComponent({
           align: 'left',
           field: 'catchNum',
           width: '80',
-          isEditable: false
+          isEditable: false,
+          order: 3
         },
         {
           name: 'disposition',
@@ -82,7 +85,8 @@ export default createComponent({
           isEditable: true,
           type: 'toggle-search',
           lookupView: 'catch-disposition',
-          lookupField: 'legacy.lookupVal'
+          lookupField: 'legacy.lookupVal',
+          order: 4
         },
         {
           name: 'weightMethod',
@@ -94,7 +98,8 @@ export default createComponent({
           isEditable: true,
           type: 'toggle-search',
           lookupView: 'weight-method',
-          lookupField: 'description'
+          lookupField: 'description',
+          order: 5
         },
         {
           name: 'name',
@@ -106,7 +111,8 @@ export default createComponent({
           isEditable: true,
           type: 'toggle-search',
           lookupView: 'taxonomy-alias',
-          lookupField: 'displayName'
+          lookupField: 'displayName',
+          order: 6
         },
         {
           name: 'count',
@@ -115,7 +121,8 @@ export default createComponent({
           field: 'count',
           width: '100',
           type: 'number',
-          isEditable: true
+          isEditable: true,
+          order: 7
         },
         {
           name: 'weight',
@@ -124,7 +131,8 @@ export default createComponent({
           field: 'weight',
           type: 'double',
           width: '100',
-          isEditable: true
+          isEditable: true,
+          order: 8
         },
         {
           name: 'basketCnt',
@@ -133,7 +141,8 @@ export default createComponent({
           field: 'basketCnt',
           type: 'double',
           width: '70',
-          isEditable: false
+          isEditable: false,
+          order: 9
         },
         {
           name: 'specimensCnt',
@@ -145,7 +154,8 @@ export default createComponent({
           highlightIds: 'specimenIds',
           tooltipLabel: 'toolTipInfo',
           width: '70',
-          isEditable: false
+          isEditable: false,
+          order: 10
         },
         {
           name: 'avgWt',
@@ -154,7 +164,8 @@ export default createComponent({
           field: 'avgWt',
           type: 'double',
           width: '100',
-          isEditable: false
+          isEditable: false,
+          order: 11
         },
         {
           name: 'discardReason',
@@ -166,7 +177,8 @@ export default createComponent({
           isEditable: true,
           type: 'toggle-search',
           lookupView: 'discard-reason',
-          lookupField: 'description'
+          lookupField: 'description',
+          order: 12
         }
     ];
 

--- a/apps/obs-web/src/views/DebrieferCatches.vue
+++ b/apps/obs-web/src/views/DebrieferCatches.vue
@@ -179,7 +179,17 @@ export default createComponent({
           lookupView: 'discard-reason',
           lookupField: 'description',
           order: 12
-        }
+        },
+        {
+          name: 'raio',
+          align: 'left',
+          header: 'Ratio',
+          field: 'ratio',
+          type: 'double',
+          width: '100',
+          isEditable: true,
+          order: 13
+        },
     ];
 
     watch(() => state.debriefer.selectedTrips, getCatches);
@@ -354,7 +364,6 @@ export default createComponent({
     async function save(newRecord: any) {
       store.dispatch('debriefer/updateCatches', WcgopCatches.value);
       const masterDB: Client<any> = couchService.masterDB;
-      const u = unflatten(state.debriefer.selectedOperations[0], {delimiter: '-'});
 
       const columnInfo = newRecord.data.column;
       const recordInfo = newRecord.data.node;

--- a/apps/obs-web/src/views/DebrieferLayout.vue
+++ b/apps/obs-web/src/views/DebrieferLayout.vue
@@ -4,8 +4,7 @@
           v-model="topTab"
           align="left"
           dense
-          class="q-ma-sm bg-primary text-white shadow-2"
-          narrow-indicator
+          class="q-mt-sm bg-primary text-white shadow-2"
         >
           <q-tab name="evaluation" label="Evaluation" />
           <q-tab name="search" label="Search" />
@@ -63,14 +62,14 @@
           v-model="bottomTab"
           align="left"
           dense
-          class="q-ma-sm bg-primary text-white shadow-2"
+          class="bg-primary text-white shadow-2"
           narrow-indicator
         >
           <q-tab name="data" label="Data" />
           <q-tab name="errors" label="Errors" />
           <q-tab name="summary" label="Summary" />
-          <q-tab name="assessement" label="Assessement" />
-          <q-tab name="dcs" label="DCS" />
+          <q-tab v-if="topTab === 'evaluation'" name="assessement" label="Assessement" />
+          <q-tab v-if="topTab === 'evaluation'" name="dcs" label="DCS" />
         </q-tabs>
 
     <q-tab-panels v-model="bottomTab" animated>

--- a/apps/obs-web/src/views/DebrieferLayout.vue
+++ b/apps/obs-web/src/views/DebrieferLayout.vue
@@ -49,7 +49,7 @@
             <q-tooltip>Expand / hide</q-tooltip>
           </q-btn>
       </q-tabs>
-      <q-tab-panels v-model="topTab" animated :keep-alive="true">
+      <q-tab-panels v-model="topTab" animated>
       <q-tab-panel name="evaluation" v-show="show">
         <app-debriefer-wcgop-evaluation class="z-index5 1"/>
       </q-tab-panel>

--- a/apps/obs-web/src/views/DebrieferSummary.vue
+++ b/apps/obs-web/src/views/DebrieferSummary.vue
@@ -12,7 +12,7 @@
             <template #header>
                 <div>Vessels</div>
             </template>
-            <template #empty>No Data</template>
+            <template #empty>No trips selected on the data page</template>
             <Column selectionMode="single" headerStyle="width: 3em"></Column>
             <Column field="vessel" header="Vessel"></Column>
             <Column field="tripCnt" header="Trips"></Column>
@@ -454,10 +454,15 @@ export default createComponent({
 
             for (const vessel of Object.keys(vesselGroups)) {
                 const currVesselInfo = vesselGroups[vessel];
+                const tripIds = jp.query(currVesselInfo, '$[*].legacy.tripId');
 
                 let operationIds = jp.query(currVesselInfo , '$[*].operationIDs');
                 operationIds = flattenDeep(operationIds);
-                const operations = state.debriefer.operations;
+                const operations = filter(state.debriefer.operations, (operation: any) => {
+                    if (tripIds.includes(operation.legacy.tripId)) {
+                        return operation;
+                    }
+                });
 
                 let gearType = jp.query(operations, '$[*].gearType.description');
                 gearType = uniq(gearType).join(',');

--- a/apps/obs-web/src/views/DebrieferWcgopEvaluation.vue
+++ b/apps/obs-web/src/views/DebrieferWcgopEvaluation.vue
@@ -181,6 +181,7 @@ export default createComponent({
 
     function clearFilters() {
       store.dispatch('debriefer/updateSelectedTrips', []);
+      store.dispatch('debriefer/setTripIds', []);
       store.dispatch('debriefer/updateOperations', []);
       store.dispatch('debriefer/updateSelectedOperations', []);
       store.dispatch('debriefer/updateFilters', {});

--- a/apps/obs-web/src/views/PrimeTable.vue
+++ b/apps/obs-web/src/views/PrimeTable.vue
@@ -323,9 +323,9 @@ export default createComponent({
       const initFilters = state.debriefer.filters[tableType];
       filters.value = initFilters ? initFilters : {};
       if (tableType === 'wcgop-Operations' && displayMode === trawlMode) {
-        displayColumns.value = setTrawlMode(stateDisplayCols[tableType]);
+        displayColumns.value = setTrawlMode(displayColumns.value);
       } else if (tableType === 'wcgop-Operations' && displayMode === fixedGearMode) {
-        displayColumns.value = setFixedGearMode(stateDisplayCols[tableType]);
+        displayColumns.value = setFixedGearMode(displayColumns.value);
       }
     });
 

--- a/libs/bn-common/src/components/BoatnetTreeTable.vue
+++ b/libs/bn-common/src/components/BoatnetTreeTable.vue
@@ -163,7 +163,7 @@
 import { createComponent, ref, computed, onMounted, reactive } from '@vue/composition-api';
 import { Vue } from 'vue-property-decorator';
 import { getCouchLookupInfo } from '../helpers/getLookupsInfo';
-import { cloneDeep, find, get, remove, uniq } from 'lodash';
+import { cloneDeep, find, get, orderBy, remove, uniq } from 'lodash';
 
 import { couchService } from '@boatnet/bn-couch';
 import { Client } from 'davenport';
@@ -288,6 +288,7 @@ export default createComponent ({
         } else {
           currCols.value = stateDisplayCols[tableType];
         }
+        currCols.value = orderBy(currCols.value, ['order']);
         return currCols.value;
       },
       set: (val) => {

--- a/libs/bn-common/src/components/BoatnetTreeTable.vue
+++ b/libs/bn-common/src/components/BoatnetTreeTable.vue
@@ -63,7 +63,7 @@
           'width: ' + col.codeWidth + 'px' :
           'width: ' + col.width + 'px'"
         :style="'width:' +  col.width + 'px'"
-        filterMatchMode="contains"
+        :filterMatchMode="col.type === 'toggle-search' ? 'in' : 'startsWith'"
         headerClass="sticky top table-cell"
         bodyClass="table-cell"
       >


### PR DESCRIPTION
Getting summary page to react on vessel changes
Getting rid of small arrows that shows up on tabs
Adding ratio for WM 15 on catch page. 
Hiding assessment and DCS when on search page
Ensuring columns toggle on and off in order on catch page 

https://github.com/nwfsc-fram/boatnet/issues/2315